### PR TITLE
Fix SRAM macro name in sram:tsmc28.sv

### DIFF
--- a/lib/utils/sram:tsmc28.sv
+++ b/lib/utils/sram:tsmc28.sv
@@ -1,4 +1,3 @@
-// Wrapper for TSMC 28nm SRAM macros
 module sram #(
     parameter WIDTH = 8,
     parameter DEPTH = 256
@@ -36,7 +35,7 @@ if (WIDTH == 256 && DEPTH == 64) begin : sram_256x64
       .AWT(0),
       .CLK(clk)
       );
-    TS28HPCUHDB64X128M4MWB sram_macro_1 (
+    TSDN28HPCPUHDB64X128M4MWA sram_macro_1 (
       .RTSEL(2'b00),
       .WTSEL(2'b00),
       .PTSEL(2'b00),


### PR DESCRIPTION
Fixes #17

Change the SRAM macro name in `lib/utils/sram:tsmc28.sv` from `TS28HPCUHDB64X128M4MWB` to `TSDN28HPCPUHDB64X128M4MWA`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/silagokth/drra-component-lib/pull/19?shareId=60174164-2fd3-45bc-bcb3-bef3786095a9).