### PR TITLE
2.2.0 doc, workflow and naming update

### DIFF
--- a/.github/workflows/ci-build-base.yml
+++ b/.github/workflows/ci-build-base.yml
@@ -2,13 +2,6 @@ name: Build testcases and library without SST
 
 on:
   workflow_call:
-    # inputs:
-    #   config-path:
-    #     required: true
-    #     type: string
-    # secrets:
-    #   personal_access_token:
-    #     required: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci-build-base.yml
+++ b/.github/workflows/ci-build-base.yml
@@ -42,20 +42,20 @@ jobs:
         chmod +x bender
         mkdir -p /home/runner/.local/bin
         mv bender /home/runner/.local/bin
-    - name: Download vesyla-suite-4
-      run: gh release download --repo silagokth/vesyla-suite-4 --pattern "vesyla-suite"
+    - name: Download vesyla
+      run: gh release download --repo silagokth/vesyla --pattern "vesyla"
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install vesyla-suite
+    - name: Install vesyla
       run: |
-        chmod +x vesyla-suite
+        chmod +x vesyla
         mkdir -p /home/runner/.local/bin
-        mv vesyla-suite /home/runner/.local/bin
+        mv vesyla /home/runner/.local/bin
     - name: Assemble testcases
       run: |
         cd testcases
         for testcase in $(ls *.json); do
-          vesyla-suite component assemble -a $testcase -o ${testcase%.*}
+          vesyla component assemble -a $testcase -o ${testcase%.*}
         done
         ls
     - run: tar czf testcases.tar.gz testcases/

--- a/.github/workflows/ci-build-sst.yml
+++ b/.github/workflows/ci-build-sst.yml
@@ -153,23 +153,23 @@ jobs:
         mkdir -p /home/runner/.local/bin
         mv bender /home/runner/.local/bin
 
-    - name: Download vesyla-suite-4
-      run: gh release download --repo silagokth/vesyla-suite-4 --pattern "vesyla-suite"
+    - name: Download vesyla
+      run: gh release download --repo silagokth/vesyla --pattern "vesyla"
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install vesyla-suite
+    - name: Install vesyla
       run: |
-        chmod +x vesyla-suite
+        chmod +x vesyla
         mkdir -p /home/runner/.local/bin
-        mv vesyla-suite /home/runner/.local/bin
+        mv vesyla /home/runner/.local/bin
 
     - name: Assemble and check testcases
       run: |
         cd testcases
         for testcase in $(ls *.json); do
           echo "Processing testcase: $testcase"
-          vesyla-suite component assemble -a $testcase -o ${testcase%.*}
+          vesyla component assemble -a $testcase -o ${testcase%.*}
           touch ${testcase%.*}/sst/io_input_buffer.bin
           touch ${testcase%.*}/sst/io_output_buffer.bin
           cd ${testcase%.*}/sst/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,7 @@
-# This workflow gets triggered when a release is published. It calls the build job to build the testcases and library
-# and then the assemble_testcases job to assemble the testcases. The testcases are then uploaded as an artifact.
-# Then they are added to the release as a downloadable asset.
-
 name: Create release
 
 on:
-  # release:
-  #   types: [published]
   push:
-    branches:
-      - master
     tags:
       - 'v*'
 
@@ -20,15 +12,52 @@ jobs:
     needs: ci-build-sst
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get version from tag
+        id: get_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Extract release notes
+        id: extract_release_notes
+        run: |
+          SECTION=$(awk -v ver="${{ steps.get_version.outputs.VERSION }}" '
+            BEGIN { found=0; capture=0; first_line=1; }
+            /^## \[[0-9]+\.[0-9]+\.[0-9]+\] - / {
+              if (found == 1 && $0 !~ "\\[" ver "\\]") { 
+                exit; 
+              }
+              if ($0 ~ "\\[" ver "\\]") { 
+                found=1; 
+                first_line=1;
+                next;  # Skip the version header line
+              }
+            }
+            { 
+              if (found == 1) { 
+                print $0;
+              } 
+            }
+          ' CHANGELOG.md)
+
+          # Save the section to a file
+          echo "$SECTION" > changelog_section.md
+
       - uses: actions/download-artifact@v4
         with:
           name: testcases
+
       - uses: actions/download-artifact@v4
         with:
           name: library
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
+          body_path: changelog_section.md
           files: |
             testcases.tar.gz
             library.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] -
+
+### Added
+
+- [CHANGELOG.md](CHANGELOG.md)
+
+### Fixed
+
+### Changed
+
+- Updated [README.md](README.md)
+  - indicating GLIBC version
+  - separating the prerequisites between "using pre-built release" or "building from source"
+  - added more details on how to use the optional sccache package
+
+### Removed
+
+## [2.1.4] - 2025-04-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] -
+## [2.2.0] - 2025-04-25
 
 ### Added
 
-- [CHANGELOG.md](CHANGELOG.md)
-
-### Fixed
+- Created [CHANGELOG.md](CHANGELOG.md)
 
 ### Changed
 
-- Updated [README.md](README.md)
+- **BREAKING CHANGE** Renamed `vesyla-suite` to `vesyla` based on [silagokth/vesyla@9a11d72](https://github.com/silagokth/vesyla/commit/9a11d72afe87d19b2a419d83e41330bed0403ed0) ([d03937f](https://github.com/silagokth/drra-components/commit/d03937f8b0a7369db92347b0d58cdc4cd5358dcc))
+- Updated [README.md](README.md) ([ff0c314](https://github.com/silagokth/drra-components/commit/ff0c314ff7bbb64ceae9e404276fa07f7e911da5))
   - indicating GLIBC version
   - separating the prerequisites between "using pre-built release" or "building from source"
   - added more details on how to use the optional sccache package
+- Updated release github workflow to include changelog in the release ([e5e0eee](https://github.com/silagokth/drra-components/commit/e5e0eeec1406410edcf9364e8b45422501795437))
 
 ### Removed
+
+- Unecessary comments in ci-build-base workflow ([836ff8b](https://github.com/silagokth/drra-components/commit/836ff8be44d7c68102e439a0608539c987649977))
 
 ## [2.1.4] - 2025-04-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Unecessary comments in ci-build-base workflow ([836ff8b](https://github.com/silagokth/drra-components/commit/836ff8be44d7c68102e439a0608539c987649977))
+- Unnecessary comments in ci-build-base workflow ([836ff8b](https://github.com/silagokth/drra-components/commit/836ff8be44d7c68102e439a0608539c987649977))
 
 ## [2.1.4] - 2025-04-22

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sst-test-elements -w "drra*"
 
 ## Usage
 
-This library should be used by the [`vesyla`](https://github.com/silagokth/vesyla-suite-4) program. To let the program know where the library is located, you need to set the `VESYLA_SUITE_PATH_COMPONENTS` environment variable to the path of the library folder. For example, if you have copied the library to `/usr/local/lib/drra-component-library`, you can set the environment variable by running the following command:
+This library should be used by [`vesyla`](https://github.com/silagokth/vesyla). To let the program know where the library is located, you need to set the `VESYLA_SUITE_PATH_COMPONENTS` environment variable to the path of the library folder. For example, if you have copied the library to `/usr/local/lib/drra-component-library`, you can set the environment variable by running the following command
 
 ```bash
 export VESYLA_SUITE_PATH_COMPONENTS=/usr/local/lib/drra-component-library

--- a/README.md
+++ b/README.md
@@ -4,19 +4,37 @@ This repository contains the DRRA component library. The library is a collection
 
 ## Prerequisites
 
-This library has the following dependencies:
+### For using [pre-built releases](https://github.com/silagokth/drra-components/releases)
+
+- GLIBC 2.35 or newer
+- [vesyla](https://github.com/silagokth/vesyla)
+  - **Option 1**: From the [pre-built releases](https://github.com/silagokth/vesyla/releases)
+  - **Option 2**: Built from [source](https://github.com/silagokth/vesyla)
+- [SST framework](https://sst-simulator.org)
+  - Install dependencies:
+    - gtest (`sudo apt-get install libgtest-dev`)
+  - [Detailed Build and Installation Instructions](https://sst-simulator.org/SSTPages/SSTBuildAndInstall_14dot1dot0_SeriesDetailedBuildInstructions/)
+  - **Make sure that `SST_CORE_HOME` and `SST_ELEMENTS_HOME` are correctly set in your ENV**
+
+### For building from source
 
 - cmake
 - make
 - [rust](https://www.rust-lang.org/learn/get-started)
-- (Optional) [sccache](https://lib.rs/crates/sccache) (to build faster)
+- (Optional, to run ISA-level simulations) [SST framework](https://sst-simulator.org)
+- (Optional, to build faster) [sccache](https://lib.rs/crates/sccache). After installation, you'll need to configure it using one of these methods:
+  - **Option 1**: Configure via environment variables:
 
-If you want to be able to run SST simulations:
-- [SST framework](https://sst-simulator.org)
-  - [Detailed Build and Installation Instructions](https://sst-simulator.org/SSTPages/SSTBuildAndInstall_14dot1dot0_SeriesDetailedBuildInstructions/)
-  - **Make sure that `SST_CORE_HOME` and `SST_ELEMENTS_HOME` are correctly set in your ENV**
-- gtest (`sudo apt-get install libgtest-dev`)
+    ```bash
+    export RUSTC_WRAPPER=/path/to/sccache
+    ```
 
+  - **Option 2**: Configure globally by setting it in `$HOME/.cargo/config.toml`:
+
+    ```toml
+    [build]
+    rustc-wrapper = "/path/to/sccache"
+    ```
 
 ## Compilation and Installation
 
@@ -29,7 +47,7 @@ cmake ..
 cmake --build .
 ```
 
-To compile the library without SST, run the following commands:
+To compile the library _without SST_, run the following commands:
 
 ```bash
 mkdir build
@@ -50,7 +68,7 @@ sst-test-elements -w "drra*"
 
 ## Usage
 
-This library should be used by the [Vesyla-Suite](https://github.com/silagokth/vesyla-suite-4) program. To let the program know where the library is located, you need to set the `VESYLA_SUITE_PATH_COMPONENTS` environment variable to the path of the library. For example, if you have copied the library to `/usr/local/lib/drra-component-library`, you can set the environment variable by running the following command:
+This library should be used by the [`vesyla`](https://github.com/silagokth/vesyla-suite-4) program. To let the program know where the library is located, you need to set the `VESYLA_SUITE_PATH_COMPONENTS` environment variable to the path of the library folder. For example, if you have copied the library to `/usr/local/lib/drra-component-library`, you can set the environment variable by running the following command:
 
 ```bash
 export VESYLA_SUITE_PATH_COMPONENTS=/usr/local/lib/drra-component-library


### PR DESCRIPTION
# WARNING: this PR depends on https://github.com/silagokth/vesyla/pull/47
First merge https://github.com/silagokth/vesyla/pull/47 before rerunning the workflows and merging this PR

## [2.2.0] - 2025-04-25

### Added

- Created [CHANGELOG.md](CHANGELOG.md)

### Changed

- **BREAKING CHANGE** Renamed `vesyla-suite` to `vesyla` based on [silagokth/vesyla@9a11d72](https://github.com/silagokth/vesyla/commit/9a11d72afe87d19b2a419d83e41330bed0403ed0) ([d03937f](https://github.com/silagokth/drra-components/commit/d03937f8b0a7369db92347b0d58cdc4cd5358dcc))
- Updated [README.md](README.md) ([ff0c314](https://github.com/silagokth/drra-components/commit/ff0c314ff7bbb64ceae9e404276fa07f7e911da5))
  - indicating GLIBC version
  - separating the prerequisites between "using pre-built release" or "building from source"
  - added more details on how to use the optional sccache package
- Updated release github workflow to include changelog in the release ([e5e0eee](https://github.com/silagokth/drra-components/commit/e5e0eeec1406410edcf9364e8b45422501795437))

### Removed

- Unecessary comments in ci-build-base workflow ([836ff8b](https://github.com/silagokth/drra-components/commit/836ff8be44d7c68102e439a0608539c987649977))