### PR TITLE
hotfix: modified isa docs script to accept input path

### DIFF
--- a/.github/workflows/ci-draft-release.yml
+++ b/.github/workflows/ci-draft-release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build ISA documentation
         run: |
           mkdir -p build
-          bash ./scripts/build_isa_doc.sh ./build/InstructionSet.md
+          bash ./scripts/build_isa_doc.sh ./build/InstructionSet.md .
 
       - name: Checkout SilagoDoc repo
         uses: actions/checkout@v4

--- a/scripts/build_isa_doc.sh
+++ b/scripts/build_isa_doc.sh
@@ -12,20 +12,27 @@ DEFAULT_OUTPUT_FILE="./InstructionSet.md"
 # Get output file path from command-line argument or use default
 OUTPUT_FILE="${1:-$DEFAULT_OUTPUT_FILE}"
 
-# Define temporary directory
-TEMP_DIR=$(mktemp -d)
-
-echo "Cloning repository to $TEMP_DIR..."
-git clone git@github.com:silagokth/drra-components.git "$TEMP_DIR" --quiet
-
-# Check if clone was successful
-if [ $? -ne 0 ]; then
-    echo "Error: Failed to clone repository"
-    rm -rf "$TEMP_DIR"
-    exit 1
+# Get drra-components path from command-line argument or clone if not provided
+if [ -z "$2" ]; then
+    CLONED=true
+    echo "No path provided for drra-components."
+    TEMP_DIR=$(mktemp -d)
+    echo "Cloning repository to $TEMP_DIR..."
+    git clone git@github.com:silagokth/drra-components.git "$TEMP_DIR" --quiet
+    # Check if clone was successful
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to clone repository"
+        rm -rf "$TEMP_DIR"
+        exit 1
+    fi
+    echo "Repository cloned successfully. Finding and processing ISA files..."
+else
+    TEMP_DIR="$2"
+    if [ ! -d "$TEMP_DIR" ]; then
+        echo "Error: The provided path does not exist or is not a directory."
+        exit 1
+    fi
 fi
-
-echo "Repository cloned successfully. Finding and processing ISA files..."
 
 # Create header for the markdown file
 cat > "$OUTPUT_FILE" << 'EOT'
@@ -217,7 +224,10 @@ find "$TEMP_DIR" -name "isa.json" | sort | while read -r isa_file; do
 done
 
 echo "Cleaning up temporary directory..."
-rm -rf "$TEMP_DIR"
+if [ "$CLONED" = true ]; then
+    # Only remove the temporary directory if we cloned it
+    rm -rf "$TEMP_DIR"
+fi
 
 echo "ISA documentation generated successfully at $OUTPUT_FILE"
 chmod +x "$0"

--- a/scripts/build_isa_doc.sh
+++ b/scripts/build_isa_doc.sh
@@ -12,6 +12,8 @@ DEFAULT_OUTPUT_FILE="./InstructionSet.md"
 # Get output file path from command-line argument or use default
 OUTPUT_FILE="${1:-$DEFAULT_OUTPUT_FILE}"
 
+CLONED=false
+
 # Get drra-components path from command-line argument or clone if not provided
 if [ -z "$2" ]; then
     CLONED=true


### PR DESCRIPTION
# hotfix: modified isa docs script to accept input path

## Description

Hotfix the isa docs script to accept an input path that points to a cloned drra-components.
This allows the script to run without using an additional personal access token.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Runs locally

**Test Configuration**:

- OS: Ubuntu 22.04
- Vesyla version: _v4.1.2_

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
