### PR TITLE
fix: resolved slow cmake by adding submodule and cache variables

### DIFF
--- a/.github/workflows/ci-build-library.yml
+++ b/.github/workflows/ci-build-library.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        submodules: true
 
     - name: Restore SST Cache
       uses: actions/cache@v4

--- a/.github/workflows/ci-create-isa-doc.yml
+++ b/.github/workflows/ci-create-isa-doc.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Get version from tag
         id: get_version

--- a/.github/workflows/ci-draft-release.yml
+++ b/.github/workflows/ci-draft-release.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Get version from tag
         id: get_version

--- a/.github/workflows/ci-sst-install.yml
+++ b/.github/workflows/ci-sst-install.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        submodules: true
 
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "cmake/modules/corrosion"]
+	path = cmake/modules/corrosion
+	url = https://github.com/corrosion-rs/corrosion.git
+	branch = stable/v0.5

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ This repository contains the DRRA component library. The library is a collection
     [build]
     rustc-wrapper = "/path/to/sccache"
     ```
+## Cloning the repo
+
+This repo contains submodules.
+Use the following command to clone it:
+
+```bash
+git clone --recurse-submodules git@github.com:silagokth/drra-components.git
+```
+
+Or, if the repo was already cloned:
+```bash
+git submodule update --init
+```
 
 ## Compilation and Installation
 

--- a/cmake/modules/FindDRRAUtils.cmake
+++ b/cmake/modules/FindDRRAUtils.cmake
@@ -1,16 +1,24 @@
 function(cargo_build FOLDER)
-    include(FetchContent)
-    FetchContent_Declare(
-        Corrosion
-        GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.5.2
-    )
-    FetchContent_MakeAvailable(Corrosion)
+    if(NOT DEFINED CORROSION_FETCHED OR NOT CORROSION_FETCHED)
+        add_subdirectory(
+            ${CMAKE_SOURCE_DIR}/cmake/modules/corrosion
+            ${CMAKE_BINARY_DIR}/corrosion-build
+            EXCLUDE_FROM_ALL
+        )
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/corrosion/cmake")
+        include(Corrosion)
+
+        set(
+            CORROSION_FETCHED TRUE
+            CACHE INTERNAL
+            "Wether Corrosion has been fetched"
+        )
+    endif()
 
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_COMPONENTS_OUTPUT_DIRECTORY})
 
     get_filename_component(FOLDER_NAME ${FOLDER} NAME)
-    message(STATUS "FOLDER_NAME: ${FOLDER_NAME}")
+    message(STATUS "Found Rust project: ${FOLDER}")
 
     # Create temporary directory
     file(MAKE_DIRECTORY "${CMAKE_COMPONENTS_OUTPUT_DIRECTORY}/temp")

--- a/cmake/modules/FindDRRAUtils.cmake
+++ b/cmake/modules/FindDRRAUtils.cmake
@@ -1,12 +1,24 @@
 function(cargo_build FOLDER)
     if(NOT DEFINED CORROSION_FETCHED OR NOT CORROSION_FETCHED)
-        add_subdirectory(
-            ${CMAKE_SOURCE_DIR}/cmake/modules/corrosion
-            ${CMAKE_BINARY_DIR}/corrosion-build
-            EXCLUDE_FROM_ALL
-        )
-        list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/corrosion/cmake")
-        include(Corrosion)
+        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/cmake/modules/corrosion")
+            message(STATUS "Fetching Corrosion")
+            include(FetchContent)
+            FetchContent_Declare(
+                Corrosion
+                GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+                GIT_TAG v0.5.2
+            )
+            FetchContent_MakeAvailable(Corrosion)
+        else()
+            message(STATUS "Using Corrosion submodule")
+            add_subdirectory(
+                ${CMAKE_SOURCE_DIR}/cmake/modules/corrosion
+                ${CMAKE_BINARY_DIR}/corrosion-build
+                EXCLUDE_FROM_ALL
+            )
+            list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/corrosion/cmake")
+            include(Corrosion)
+        endif()
 
         set(
             CORROSION_FETCHED TRUE

--- a/cmake/modules/FindDRRAUtils.cmake
+++ b/cmake/modules/FindDRRAUtils.cmake
@@ -23,7 +23,7 @@ function(cargo_build FOLDER)
         set(
             CORROSION_FETCHED TRUE
             CACHE INTERNAL
-            "Wether Corrosion has been fetched"
+            "Whether Corrosion has been fetched"
         )
     endif()
 

--- a/cmake/modules/FindSST.cmake
+++ b/cmake/modules/FindSST.cmake
@@ -20,27 +20,75 @@ if(NOT SST_EXECUTABLE)
     message(FATAL_ERROR "SST executable not found. Please set the SST_CORE_HOME environment variable.")
 endif()
 
+# Cache variables
+set(SST_VERSION_CACHE "" CACHE STRING "Cached SST version")
+set(SST_INCLUDE_DIR_CACHE "" CACHE PATH "Cache SST include directory")
+set(SST_CXX_FLAGS_CACHE "" CACHE STRING "Cache SST CXX flags")
+
 # Get SST include directory
-if(SST_EXECUTABLE)
-    execute_process(
-        COMMAND ${SST_EXECUTABLE} --version
-        OUTPUT_VARIABLE SST_VERSION
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+if(SST_EXECUTABLE AND(SST_VERSION_CACHE STREQUAL "" OR DEFINED RESET_SST_CACHE))
+    message(STATUS "Fetching SST configuration")
 
-    execute_process(
-        COMMAND sst-config --includedir
-        OUTPUT_VARIABLE SST_INCLUDE_DIR
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.10)
+        # Get SST version from CLI
+        execute_process(
+            COMMAND ${SST_EXECUTABLE} --version
+            OUTPUT_VARIABLE SST_VERSION_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            COMMAND_ECHO NONE
+        )
 
-    # Also grab CXXFLAGS which might contain important compile definitions
-    execute_process(
-        COMMAND sst-config --CXXFLAGS
-        OUTPUT_VARIABLE SST_CXX_FLAGS
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+        # Get SST include directory
+        execute_process(
+            COMMAND sst-config --includedir
+            OUTPUT_VARIABLE SST_INCLUDE_DIR_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            COMMAND_ECHO NONE
+        )
+
+        # Get SST CXX flags
+        execute_process(
+            COMMAND sst-config --CXXFLAGS
+            OUTPUT_VARIABLE SST_CXX_FLAGS_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            COMMAND_ECHO NONE
+        )
+    else() # Run sequentially for older CMAKE versions
+        execute_process(
+            COMMAND ${SST_EXECUTABLE} --version
+            OUTPUT_VARIABLE SST_VERSION_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        execute_process(
+            COMMAND sst-config --includedir
+            OUTPUT_VARIABLE SST_INCLUDE_DIR_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        execute_process(
+            COMMAND sst-config --CXXFLAGS
+            OUTPUT_VARIABLE SST_CXX_FLAGS_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    endif()
+
+    # Update SST cache variables
+    if(SST_VERSION_RESULT AND SST_INCLUDE_DIR_RESULT AND SST_CXX_FLAGS_RESULT)
+        set(SST_VERSION_CACHE "${SST_VERSION_RESULT}" CACHE STRING "Cached SST version" FORCE)
+        set(SST_INCLUDE_DIR_CACHE "${SST_INCLUDE_DIR_RESULT}" CACHE PATH "Cached SST include directory" FORCE)
+        set(SST_CXX_FLAGS_CACHE "${SST_CXX_FLAGS_RESULT}" CACHE STRING "Cached SST CXX flags" FORCE)
+    else()
+        message(FATAL_ERROR "Failed to retrieve SST configuration. Please check your SST installation.")
+    endif()
+
+    message(STATUS "SST version: ${SST_VERSION_CACHE}")
+    message(STATUS "SST include directory: ${SST_INCLUDE_DIR_CACHE}")
+    message(STATUS "SST CXX flags: ${SST_CXX_FLAGS_CACHE}")
 endif()
+
+# Use the cache variables directly
+set(SST_VERSION "${SST_VERSION_CACHE}")
+set(SST_INCLUDE_DIR "${SST_INCLUDE_DIR_CACHE}")
+set(SST_CXX_FLAGS "${SST_CXX_FLAGS_CACHE}")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(SST


### PR DESCRIPTION
# fix: resolved slow cmake by adding submodule and cache variables

## Description

Added corrosion as a submodule in `cmake/modules`.
Added cache variables for SST_VERSION, SST_INCLUDE_DIR & SST_CXX_FLAGS to avoid running the CLI commands for each component.
The cmake configuration speed went from **6.2s** to **1.7s**, the build time remains the same (**33.5s**).

Documentation commit: eef7ad488569a15a2838f71ae9d97fce71b1ed15 (updated README file)

### Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?

- This was tested locally with and without cloning the corrosion submodule.
- Latest drra-tests pass correctly.

**Test Configuration**:

- OS: Ubuntu 22.04
- Vesyla version: _v4.2.0_

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
