### PR TITLE
fix(build): correct path check for Corrosion module in cmake

### DIFF
--- a/cmake/modules/FindDRRAUtils.cmake
+++ b/cmake/modules/FindDRRAUtils.cmake
@@ -1,6 +1,6 @@
 function(cargo_build FOLDER)
     if(NOT DEFINED CORROSION_FETCHED OR NOT CORROSION_FETCHED)
-        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/cmake/modules/corrosion")
+        if(NOT EXISTS "${CMAKE_SOURCE_DIR}/cmake/modules/corrosion/CMakeLists.txt")
             message(STATUS "Fetching Corrosion")
             include(FetchContent)
             FetchContent_Declare(


### PR DESCRIPTION
# fix(build): correct path check for Corrosion module in cmake

## Description

Fixes #73 

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

```bash
git clone git@github.com:silagokth/drra-components.git
cd drra-components
mkcd build
cmake ..
cmake --build .
```

**Test Configuration**:

- OS: Ubuntu 22.04
- Vesyla version: _v4.2.0_

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
