### PR TITLE
fix: cmake error when building without SST

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ if(USE_SST)
     COMMAND sst-register drra drra_LIBDIR=${CMAKE_CURRENT_BINARY_DIR}/library
     COMMAND sst-register SST_ELEMENT_TESTS drra=${CMAKE_CURRENT_SOURCE_DIR}/sst_tests
   )
+else()
+  add_library(drra INTERFACE)
 endif()
 
 # The project version number.

--- a/cmake/modules/FindSST.cmake
+++ b/cmake/modules/FindSST.cmake
@@ -1,5 +1,18 @@
 # FindSST.cmake - Find SST package
 
+if(USE_SST)
+  message(STATUS "USE_SST is enabled, proceeding with SST package search.")
+else()
+  message(STATUS "USE_SST is disabled, skipping SST package search.")
+  function(sst_build)
+    message(
+      STATUS
+      "SST build function is not called because USE_SST is disabled."
+    )
+  endfunction()
+  return()
+endif()
+
 set(SST_PREFIX $ENV{SST_CORE_HOME})
 
 # Find the SST executable
@@ -17,7 +30,10 @@ if(NOT SST_EXECUTABLE)
     message(STATUS "  ${FILE}")
   endforeach()
 
-  message(FATAL_ERROR "SST executable not found. Please set the SST_CORE_HOME environment variable.")
+  message(
+    FATAL_ERROR
+    "SST executable not found. Set the SST_CORE_HOME environment variable."
+  )
 endif()
 
 # Cache variables
@@ -128,6 +144,7 @@ mark_as_advanced(SST_EXECUTABLE SST_INCLUDE_DIR SST_CXX_FLAGS)
 
 function(sst_build)
   if(USE_SST)
+    find_package(SST REQUIRED)
     set(options)
     set(oneValueArgs OVERRIDE_SOURCE_NAME)
     set(multiValueArgs)

--- a/cmake/modules/FindSST.cmake
+++ b/cmake/modules/FindSST.cmake
@@ -9,15 +9,15 @@ find_program(SST_EXECUTABLE sst
 )
 
 if(NOT SST_EXECUTABLE)
-    message(STATUS "SST_PREFIX: ${SST_PREFIX}")
-    file(GLOB SST_BIN_FILES ${SST_PREFIX}/bin/*)
-    message(STATUS "Contents of ${SST_PREFIX}/bin:")
+  message(STATUS "SST_PREFIX: ${SST_PREFIX}")
+  file(GLOB SST_BIN_FILES ${SST_PREFIX}/bin/*)
+  message(STATUS "Contents of ${SST_PREFIX}/bin:")
 
-    foreach(FILE ${SST_BIN_FILES})
-        message(STATUS "  ${FILE}")
-    endforeach()
+  foreach(FILE ${SST_BIN_FILES})
+    message(STATUS "  ${FILE}")
+  endforeach()
 
-    message(FATAL_ERROR "SST executable not found. Please set the SST_CORE_HOME environment variable.")
+  message(FATAL_ERROR "SST executable not found. Please set the SST_CORE_HOME environment variable.")
 endif()
 
 # Cache variables
@@ -27,62 +27,77 @@ set(SST_CXX_FLAGS_CACHE "" CACHE STRING "Cache SST CXX flags")
 
 # Get SST include directory
 if(SST_EXECUTABLE AND(SST_VERSION_CACHE STREQUAL "" OR DEFINED RESET_SST_CACHE))
-    message(STATUS "Fetching SST configuration")
+  message(STATUS "Fetching SST configuration")
 
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.10)
-        # Get SST version from CLI
-        execute_process(
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.10)
+    # Get SST version from CLI
+    execute_process(
             COMMAND ${SST_EXECUTABLE} --version
             OUTPUT_VARIABLE SST_VERSION_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
             COMMAND_ECHO NONE
         )
 
-        # Get SST include directory
-        execute_process(
+    # Get SST include directory
+    execute_process(
             COMMAND sst-config --includedir
             OUTPUT_VARIABLE SST_INCLUDE_DIR_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
             COMMAND_ECHO NONE
         )
 
-        # Get SST CXX flags
-        execute_process(
+    # Get SST CXX flags
+    execute_process(
             COMMAND sst-config --CXXFLAGS
             OUTPUT_VARIABLE SST_CXX_FLAGS_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
             COMMAND_ECHO NONE
         )
-    else() # Run sequentially for older CMAKE versions
-        execute_process(
+  else() # Run sequentially for older CMAKE versions
+    execute_process(
             COMMAND ${SST_EXECUTABLE} --version
             OUTPUT_VARIABLE SST_VERSION_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
-        execute_process(
+    execute_process(
             COMMAND sst-config --includedir
             OUTPUT_VARIABLE SST_INCLUDE_DIR_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
-        execute_process(
+    execute_process(
             COMMAND sst-config --CXXFLAGS
             OUTPUT_VARIABLE SST_CXX_FLAGS_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
-    endif()
+  endif()
 
-    # Update SST cache variables
-    if(SST_VERSION_RESULT AND SST_INCLUDE_DIR_RESULT AND SST_CXX_FLAGS_RESULT)
-        set(SST_VERSION_CACHE "${SST_VERSION_RESULT}" CACHE STRING "Cached SST version" FORCE)
-        set(SST_INCLUDE_DIR_CACHE "${SST_INCLUDE_DIR_RESULT}" CACHE PATH "Cached SST include directory" FORCE)
-        set(SST_CXX_FLAGS_CACHE "${SST_CXX_FLAGS_RESULT}" CACHE STRING "Cached SST CXX flags" FORCE)
-    else()
-        message(FATAL_ERROR "Failed to retrieve SST configuration. Please check your SST installation.")
-    endif()
+  # Update SST cache variables
+  if(SST_VERSION_RESULT AND SST_INCLUDE_DIR_RESULT AND SST_CXX_FLAGS_RESULT)
+    set(
+      SST_VERSION_CACHE "${SST_VERSION_RESULT}"
+      CACHE STRING "Cached SST version"
+      FORCE
+    )
+    set(
+      SST_INCLUDE_DIR_CACHE "${SST_INCLUDE_DIR_RESULT}"
+      CACHE PATH "Cached SST include directory"
+      FORCE
+    )
+    set(
+      SST_CXX_FLAGS_CACHE "${SST_CXX_FLAGS_RESULT}"
+      CACHE STRING "Cached SST CXX flags"
+      FORCE
+    )
+  else()
+    message(
+      FATAL_ERROR
+      "Failed to retrieve SST configuration. Check your SST installation."
+    )
+  endif()
 
-    message(STATUS "SST version: ${SST_VERSION_CACHE}")
-    message(STATUS "SST include directory: ${SST_INCLUDE_DIR_CACHE}")
-    message(STATUS "SST CXX flags: ${SST_CXX_FLAGS_CACHE}")
+  message(STATUS "SST version: ${SST_VERSION_CACHE}")
+  message(STATUS "SST include directory: ${SST_INCLUDE_DIR_CACHE}")
+  message(STATUS "SST CXX flags: ${SST_CXX_FLAGS_CACHE}")
 endif()
 
 # Use the cache variables directly
@@ -97,27 +112,27 @@ find_package_handle_standard_args(SST
 )
 
 if(SST_FOUND)
-    if(NOT TARGET SST::SST)
-        add_library(SST::SST INTERFACE IMPORTED)
-        set_target_properties(SST::SST PROPERTIES
+  if(NOT TARGET SST::SST)
+    add_library(SST::SST INTERFACE IMPORTED)
+    set_target_properties(SST::SST PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${SST_INCLUDE_DIR}"
             INTERFACE_COMPILE_OPTIONS "${SST_CXX_FLAGS}"
         )
-    endif()
+  endif()
 
-    # Set traditional variables for backward compatibility
-    set(SST_INCLUDE_DIRS ${SST_INCLUDE_DIR})
+  # Set traditional variables for backward compatibility
+  set(SST_INCLUDE_DIRS ${SST_INCLUDE_DIR})
 endif()
 
 mark_as_advanced(SST_EXECUTABLE SST_INCLUDE_DIR SST_CXX_FLAGS)
 
 function(sst_build)
-    if(USE_SST)
-        set(options)
-        set(oneValueArgs OVERRIDE_SOURCE_NAME)
-        set(multiValueArgs)
+  if(USE_SST)
+    set(options)
+    set(oneValueArgs OVERRIDE_SOURCE_NAME)
+    set(multiValueArgs)
 
-        cmake_parse_arguments(
+    cmake_parse_arguments(
             SST_BUILD
             "${options}"
             "${oneValueArgs}"
@@ -125,18 +140,22 @@ function(sst_build)
             ${ARGN}
         )
 
-        if(SST_BUILD_OVERRIDE_SOURCE_NAME)
-            set(component_name ${SST_BUILD_OVERRIDE_SOURCE_NAME})
-        else()
-            cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH last_path)
-            get_filename_component(component_name "${last_path}" NAME)
-        endif()
-
-        add_library(${component_name} OBJECT ${component_name}.cpp)
-        set_property(TARGET ${component_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-        target_include_directories(${component_name} PRIVATE . ${COMMON_INCLUDE_DIRS})
-
-        target_sources(drra PRIVATE $<TARGET_OBJECTS:${component_name}>)
+    if(SST_BUILD_OVERRIDE_SOURCE_NAME)
+      set(component_name ${SST_BUILD_OVERRIDE_SOURCE_NAME})
+    else()
+      cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH last_path)
+      get_filename_component(component_name "${last_path}" NAME)
     endif()
-endfunction(sst_build)
+
+    add_library(${component_name} OBJECT ${component_name}.cpp)
+    set_property(TARGET ${component_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+    target_include_directories(
+      ${component_name}
+      PRIVATE .
+      ${COMMON_INCLUDE_DIRS}
+    )
+
+    target_sources(drra PRIVATE $<TARGET_OBJECTS:${component_name}>)
+  endif()
+endfunction()


### PR DESCRIPTION
# fix: cmake error when building without sst

## Description

This pull request introduces conditional logic to handle the `USE_SST` flag in the build system, streamlining the configuration process for projects that do not require SST support. It also includes formatting improvements for better readability and consistency in CMake scripts.

### Conditional logic for `USE_SST`:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR59-R60): Added an `else` block to define the `drra` library as an `INTERFACE` target when `USE_SST` is disabled. This ensures compatibility when SST is not in use.
* [`cmake/modules/FindSST.cmake`](diffhunk://#diff-43313a77ea69ba85bccaf44bc3cb5117ec152034236cd7eb1f929546844fdc82R3-R15): Introduced conditional logic to skip SST package search and define a placeholder `sst_build` function when `USE_SST` is disabled. This avoids unnecessary operations and provides clear messaging.

### Formatting improvements:

* [`cmake/modules/FindSST.cmake`](diffhunk://#diff-43313a77ea69ba85bccaf44bc3cb5117ec152034236cd7eb1f929546844fdc82L20-R36): Reformatted `message` and `set` commands for better readability and consistency, particularly in error messages and cache variable definitions. [[1]](diffhunk://#diff-43313a77ea69ba85bccaf44bc3cb5117ec152034236cd7eb1f929546844fdc82L20-R36) [[2]](diffhunk://#diff-43313a77ea69ba85bccaf44bc3cb5117ec152034236cd7eb1f929546844fdc82L76-R111)
* [`cmake/modules/FindSST.cmake`](diffhunk://#diff-43313a77ea69ba85bccaf44bc3cb5117ec152034236cd7eb1f929546844fdc82L138-R178): Adjusted the `target_include_directories` command in the `sst_build` function for consistent indentation and style.

Fixes #84 

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally + PR #86 

**Test Configuration**:

- OS: Ubuntu 22.04
- Vesyla version: v4.4.1-40-gd95cb75

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
