### PR TITLE
ci: added a workflow to build the library without SST

### DIFF
--- a/.github/workflows/ci-build-library-sst-off.yml
+++ b/.github/workflows/ci-build-library-sst-off.yml
@@ -1,0 +1,21 @@
+name: Build library without SST
+
+on:
+  workflow_call:
+
+jobs:
+  build-library:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Build library
+      shell: bash
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -DUSE_SST=OFF ..
+        cmake --build .

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -9,6 +9,11 @@ jobs:
     uses: ./.github/workflows/ci-sst-install.yml
     secrets: inherit
 
+  ci-build-library-sst-off:
+    name: Build DRRA Library without SST
+    uses: ./.github/workflows/ci-build-library-sst-off.yml
+    secrets: inherit
+
   ci-build-library:
     name: Build DRRA Library
     uses: ./.github/workflows/ci-build-library.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ if(USE_SST)
     COMMAND sst-register drra drra_LIBDIR=${CMAKE_CURRENT_BINARY_DIR}/library
     COMMAND sst-register SST_ELEMENT_TESTS drra=${CMAKE_CURRENT_SOURCE_DIR}/sst_tests
   )
+else()
+  add_library(drra INTERFACE)
 endif()
 
 # The project version number.

--- a/cmake/modules/FindSST.cmake
+++ b/cmake/modules/FindSST.cmake
@@ -1,5 +1,18 @@
 # FindSST.cmake - Find SST package
 
+if(USE_SST)
+  message(STATUS "USE_SST is enabled, proceeding with SST package search.")
+else()
+  message(STATUS "USE_SST is disabled, skipping SST package search.")
+  function(sst_build)
+    message(
+      STATUS
+      "SST build function is not called because USE_SST is disabled."
+    )
+  endfunction()
+  return()
+endif()
+
 set(SST_PREFIX $ENV{SST_CORE_HOME})
 
 # Find the SST executable
@@ -17,7 +30,10 @@ if(NOT SST_EXECUTABLE)
     message(STATUS "  ${FILE}")
   endforeach()
 
-  message(FATAL_ERROR "SST executable not found. Please set the SST_CORE_HOME environment variable.")
+  message(
+    FATAL_ERROR
+    "SST executable not found. Set the SST_CORE_HOME environment variable."
+  )
 endif()
 
 # Cache variables
@@ -128,6 +144,7 @@ mark_as_advanced(SST_EXECUTABLE SST_INCLUDE_DIR SST_CXX_FLAGS)
 
 function(sst_build)
   if(USE_SST)
+    find_package(SST REQUIRED)
     set(options)
     set(oneValueArgs OVERRIDE_SOURCE_NAME)
     set(multiValueArgs)

--- a/cmake/modules/FindSST.cmake
+++ b/cmake/modules/FindSST.cmake
@@ -9,15 +9,15 @@ find_program(SST_EXECUTABLE sst
 )
 
 if(NOT SST_EXECUTABLE)
-    message(STATUS "SST_PREFIX: ${SST_PREFIX}")
-    file(GLOB SST_BIN_FILES ${SST_PREFIX}/bin/*)
-    message(STATUS "Contents of ${SST_PREFIX}/bin:")
+  message(STATUS "SST_PREFIX: ${SST_PREFIX}")
+  file(GLOB SST_BIN_FILES ${SST_PREFIX}/bin/*)
+  message(STATUS "Contents of ${SST_PREFIX}/bin:")
 
-    foreach(FILE ${SST_BIN_FILES})
-        message(STATUS "  ${FILE}")
-    endforeach()
+  foreach(FILE ${SST_BIN_FILES})
+    message(STATUS "  ${FILE}")
+  endforeach()
 
-    message(FATAL_ERROR "SST executable not found. Please set the SST_CORE_HOME environment variable.")
+  message(FATAL_ERROR "SST executable not found. Please set the SST_CORE_HOME environment variable.")
 endif()
 
 # Cache variables
@@ -27,62 +27,77 @@ set(SST_CXX_FLAGS_CACHE "" CACHE STRING "Cache SST CXX flags")
 
 # Get SST include directory
 if(SST_EXECUTABLE AND(SST_VERSION_CACHE STREQUAL "" OR DEFINED RESET_SST_CACHE))
-    message(STATUS "Fetching SST configuration")
+  message(STATUS "Fetching SST configuration")
 
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.10)
-        # Get SST version from CLI
-        execute_process(
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.10)
+    # Get SST version from CLI
+    execute_process(
             COMMAND ${SST_EXECUTABLE} --version
             OUTPUT_VARIABLE SST_VERSION_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
             COMMAND_ECHO NONE
         )
 
-        # Get SST include directory
-        execute_process(
+    # Get SST include directory
+    execute_process(
             COMMAND sst-config --includedir
             OUTPUT_VARIABLE SST_INCLUDE_DIR_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
             COMMAND_ECHO NONE
         )
 
-        # Get SST CXX flags
-        execute_process(
+    # Get SST CXX flags
+    execute_process(
             COMMAND sst-config --CXXFLAGS
             OUTPUT_VARIABLE SST_CXX_FLAGS_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
             COMMAND_ECHO NONE
         )
-    else() # Run sequentially for older CMAKE versions
-        execute_process(
+  else() # Run sequentially for older CMAKE versions
+    execute_process(
             COMMAND ${SST_EXECUTABLE} --version
             OUTPUT_VARIABLE SST_VERSION_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
-        execute_process(
+    execute_process(
             COMMAND sst-config --includedir
             OUTPUT_VARIABLE SST_INCLUDE_DIR_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
-        execute_process(
+    execute_process(
             COMMAND sst-config --CXXFLAGS
             OUTPUT_VARIABLE SST_CXX_FLAGS_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
-    endif()
+  endif()
 
-    # Update SST cache variables
-    if(SST_VERSION_RESULT AND SST_INCLUDE_DIR_RESULT AND SST_CXX_FLAGS_RESULT)
-        set(SST_VERSION_CACHE "${SST_VERSION_RESULT}" CACHE STRING "Cached SST version" FORCE)
-        set(SST_INCLUDE_DIR_CACHE "${SST_INCLUDE_DIR_RESULT}" CACHE PATH "Cached SST include directory" FORCE)
-        set(SST_CXX_FLAGS_CACHE "${SST_CXX_FLAGS_RESULT}" CACHE STRING "Cached SST CXX flags" FORCE)
-    else()
-        message(FATAL_ERROR "Failed to retrieve SST configuration. Please check your SST installation.")
-    endif()
+  # Update SST cache variables
+  if(SST_VERSION_RESULT AND SST_INCLUDE_DIR_RESULT AND SST_CXX_FLAGS_RESULT)
+    set(
+      SST_VERSION_CACHE "${SST_VERSION_RESULT}"
+      CACHE STRING "Cached SST version"
+      FORCE
+    )
+    set(
+      SST_INCLUDE_DIR_CACHE "${SST_INCLUDE_DIR_RESULT}"
+      CACHE PATH "Cached SST include directory"
+      FORCE
+    )
+    set(
+      SST_CXX_FLAGS_CACHE "${SST_CXX_FLAGS_RESULT}"
+      CACHE STRING "Cached SST CXX flags"
+      FORCE
+    )
+  else()
+    message(
+      FATAL_ERROR
+      "Failed to retrieve SST configuration. Check your SST installation."
+    )
+  endif()
 
-    message(STATUS "SST version: ${SST_VERSION_CACHE}")
-    message(STATUS "SST include directory: ${SST_INCLUDE_DIR_CACHE}")
-    message(STATUS "SST CXX flags: ${SST_CXX_FLAGS_CACHE}")
+  message(STATUS "SST version: ${SST_VERSION_CACHE}")
+  message(STATUS "SST include directory: ${SST_INCLUDE_DIR_CACHE}")
+  message(STATUS "SST CXX flags: ${SST_CXX_FLAGS_CACHE}")
 endif()
 
 # Use the cache variables directly
@@ -97,27 +112,27 @@ find_package_handle_standard_args(SST
 )
 
 if(SST_FOUND)
-    if(NOT TARGET SST::SST)
-        add_library(SST::SST INTERFACE IMPORTED)
-        set_target_properties(SST::SST PROPERTIES
+  if(NOT TARGET SST::SST)
+    add_library(SST::SST INTERFACE IMPORTED)
+    set_target_properties(SST::SST PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${SST_INCLUDE_DIR}"
             INTERFACE_COMPILE_OPTIONS "${SST_CXX_FLAGS}"
         )
-    endif()
+  endif()
 
-    # Set traditional variables for backward compatibility
-    set(SST_INCLUDE_DIRS ${SST_INCLUDE_DIR})
+  # Set traditional variables for backward compatibility
+  set(SST_INCLUDE_DIRS ${SST_INCLUDE_DIR})
 endif()
 
 mark_as_advanced(SST_EXECUTABLE SST_INCLUDE_DIR SST_CXX_FLAGS)
 
 function(sst_build)
-    if(USE_SST)
-        set(options)
-        set(oneValueArgs OVERRIDE_SOURCE_NAME)
-        set(multiValueArgs)
+  if(USE_SST)
+    set(options)
+    set(oneValueArgs OVERRIDE_SOURCE_NAME)
+    set(multiValueArgs)
 
-        cmake_parse_arguments(
+    cmake_parse_arguments(
             SST_BUILD
             "${options}"
             "${oneValueArgs}"
@@ -125,18 +140,22 @@ function(sst_build)
             ${ARGN}
         )
 
-        if(SST_BUILD_OVERRIDE_SOURCE_NAME)
-            set(component_name ${SST_BUILD_OVERRIDE_SOURCE_NAME})
-        else()
-            cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH last_path)
-            get_filename_component(component_name "${last_path}" NAME)
-        endif()
-
-        add_library(${component_name} OBJECT ${component_name}.cpp)
-        set_property(TARGET ${component_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-        target_include_directories(${component_name} PRIVATE . ${COMMON_INCLUDE_DIRS})
-
-        target_sources(drra PRIVATE $<TARGET_OBJECTS:${component_name}>)
+    if(SST_BUILD_OVERRIDE_SOURCE_NAME)
+      set(component_name ${SST_BUILD_OVERRIDE_SOURCE_NAME})
+    else()
+      cmake_path(GET CMAKE_CURRENT_SOURCE_DIR PARENT_PATH last_path)
+      get_filename_component(component_name "${last_path}" NAME)
     endif()
-endfunction(sst_build)
+
+    add_library(${component_name} OBJECT ${component_name}.cpp)
+    set_property(TARGET ${component_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+    target_include_directories(
+      ${component_name}
+      PRIVATE .
+      ${COMMON_INCLUDE_DIRS}
+    )
+
+    target_sources(drra PRIVATE $<TARGET_OBJECTS:${component_name}>)
+  endif()
+endfunction()


### PR DESCRIPTION
# ci: added a workflow to build the library without SST

## Description

This pull request introduces a new workflow to build the library without SST (Structural Simulation Toolkit) and updates the CMake configuration to support this functionality. Key changes include the addition of a new GitHub Actions workflow, modifications to the CMake build system, on top of PR #85.

### GitHub Actions Workflows:
* Added a new workflow file, `.github/workflows/ci-build-library-sst-off.yml`, to build the library without SST by setting the `USE_SST` flag to `OFF` during the CMake build process.
* Updated `.github/workflows/ci-pr.yml` to include the new `ci-build-library-sst-off` job for building the library without SST.

### CMake Configuration:
* Modified `CMakeLists.txt` to add an `INTERFACE` library for `drra` when `USE_SST` is disabled, ensuring compatibility with builds that do not require SST.

### Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- In workflow

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules