### PR TITLE
feat: added a version file (`library/VERSION`) written at library compilation time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,19 @@ else()
 endif()
 
 # The project version number.
-set(VERSION_MAJOR 1 CACHE STRING "Project major version number.")
-set(VERSION_MINOR 0 CACHE STRING "Project minor version number.")
-set(VERSION_PATCH 0 CACHE STRING "Project patch version number.")
-mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
+execute_process(
+  COMMAND bash -c "git describe --tags --exact-match 2>/dev/null || git describe --always --tags"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  OUTPUT_VARIABLE DRRA_COMPONENTS_VERSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# If the DRRA_COMPONENTS_VERSION value is set, write it to a file
+if(NOT DRRA_COMPONENTS_VERSION)
+  set(DRRA_COMPONENTS_VERSION "version unknown")
+endif()
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/library/VERSION" "${DRRA_COMPONENTS_VERSION}\n")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,6 @@ endif()
 # The project version number.
 execute_process(
   COMMAND bash -c "git describe --tags --exact-match 2>/dev/null || git describe --always --tags"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   OUTPUT_VARIABLE DRRA_COMPONENTS_VERSION
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -73,7 +72,16 @@ if(NOT DRRA_COMPONENTS_VERSION)
   set(DRRA_COMPONENTS_VERSION "version unknown")
 endif()
 
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/library/VERSION" "${DRRA_COMPONENTS_VERSION}\n")
+file(
+  WRITE
+  "${CMAKE_CURRENT_BINARY_DIR}/library/VERSION"
+  "${DRRA_COMPONENTS_VERSION}\n"
+)
+
+add_custom_target(drra_version ALL
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/library/VERSION
+  COMMENT "Generating DRRA version file"
+)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 


### PR DESCRIPTION
# feat: added a version file (`library/VERSION`) written at library compilation time

## Description

This pull request updates the versioning mechanism in the `CMakeLists.txt` file to dynamically generate a version file based on Git tags or commit hashes, replacing the previous static version definition. 
* Replaced the static version variables (`VERSION_MAJOR`, `VERSION_MINOR`, `VERSION_PATCH`) with a dynamic versioning system that uses `git describe` to determine the version. If no Git information is available, a fallback value of "version unknown" is used.
* Added logic to write the determined version to a `VERSION` file in the `library` directory.
* Introduced a new custom target `drra_version` to ensure the `VERSION` file is generated as part of the build process.

### Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Tested by building locally

**Test Configuration**:

- OS: Ubuntu 22.04
- Vesyla version: _v4.4.1_

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
