### PR TITLE
ci: add manual trigger to SST install workflow

### DIFF
--- a/.github/workflows/ci-sst-install.yml
+++ b/.github/workflows/ci-sst-install.yml
@@ -2,6 +2,7 @@ name: Install SST
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 env:
   SST_CORE_HOME: ${{ github.workspace }}/sstcore


### PR DESCRIPTION
# ci: add manual trigger to SST install workflow

## Description

This pull request adds the ability to manually trigger the "Install SST" workflow in the CI pipeline.
This is needed to be able to add an SST cache on main branch that other branches can use when running workflows.

* [`.github/workflows/ci-sst-install.yml`](diffhunk://#diff-aab10463b8bc741a237cf5b8310c7d91e2be20349014d4727d10500661b9ee49R5): Added the `workflow_dispatch` event to enable manual triggering of the workflow.

### Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
