### PR TITLE
feat: SST data buffers are now declared for all DRRA resources

### DIFF
--- a/lib/common/sst/drra.h
+++ b/lib/common/sst/drra.h
@@ -274,6 +274,13 @@ public:
       }
     }
 
+    // Initialize data buffers to zero
+    for (int i = 0; i < resource_size; i++) {
+      for (int j = 0; j < word_bitwidth / 8; j++) {
+        data_buffers[i].push_back(0);
+      }
+    }
+
     // Annotate slot IDs
     for (uint8_t i = 0; i < resource_size; i++) {
       slot_ids.push_back(slot_id + i);
@@ -560,6 +567,9 @@ protected:
   std::vector<int16_t> slot_ids;
   uint8_t resource_size = 1; // Default to 1 slot
 
+  // Data buffers
+  std::map<uint32_t, std::vector<uint8_t>> data_buffers;
+
   // Timing model state for each ports
   std::map<uint32_t, TimingState> current_timing_states;
   std::map<uint32_t, TimingState> next_timing_states;
@@ -623,8 +633,9 @@ public:
       // Move the trace file to the output directory
       std::string command = "mv " + trace_name + " trace_complete.json";
       int returnCode = system(command.c_str());
-      if(returnCode != 0) {
-        out.output("WARN: Could not copy the trace file to trace_complete.json");
+      if (returnCode != 0) {
+        out.output(
+            "WARN: Could not copy the trace file to trace_complete.json");
       }
     }
   }

--- a/lib/resources/dpu/sst/dpu.cpp
+++ b/lib/resources/dpu/sst/dpu.cpp
@@ -11,13 +11,7 @@ void DPU::init(unsigned int phase) {
   out.verbose(CALL_INFO, 1, 0, "Initialized\n");
 }
 
-void DPU::setup() {
-  for (int i = 0; i < resource_size; i++) {
-    for (int j = 0; j < word_bitwidth / 8; j++) {
-      data_buffers[i].push_back(0);
-    }
-  }
-}
+void DPU::setup() {}
 
 void DPU::complete(unsigned int phase) {}
 

--- a/lib/resources/dpu/sst/dpu.h
+++ b/lib/resources/dpu/sst/dpu.h
@@ -48,7 +48,6 @@ public:
 
 private:
   // buffers
-  std::map<uint32_t, std::vector<uint8_t>> data_buffers;
   std::vector<uint8_t> accumulate_register;
 
   // Supported opcodes

--- a/lib/resources/dpu_2cycle_mac/sst/dpu_2cycle_mac.cpp
+++ b/lib/resources/dpu_2cycle_mac/sst/dpu_2cycle_mac.cpp
@@ -11,13 +11,7 @@ void DPU2CycleMac::init(unsigned int phase) {
   out.verbose(CALL_INFO, 1, 0, "Initialized\n");
 }
 
-void DPU2CycleMac::setup() {
-  for (int i = 0; i < resource_size; i++) {
-    for (int j = 0; j < word_bitwidth / 8; j++) {
-      data_buffers[i].push_back(0);
-    }
-  }
-}
+void DPU2CycleMac::setup() {}
 
 void DPU2CycleMac::complete(unsigned int phase) {}
 

--- a/lib/resources/dpu_2cycle_mac/sst/dpu_2cycle_mac.h
+++ b/lib/resources/dpu_2cycle_mac/sst/dpu_2cycle_mac.h
@@ -51,7 +51,6 @@ private:
   int MAC_phase;
 
   // buffers
-  std::map<uint32_t, std::vector<uint8_t>> data_buffers;
   std::vector<uint8_t> accumulate_register;
 
   // Supported opcodes


### PR DESCRIPTION
# feat: SST data buffers are now declared for all DRRA resources

## Description

This pull request refactors the handling of data buffers in the `DRRAResource` class and its derived classes.
The changes include moving the data buffer initialization to the base class and removing redundant code in derived classes.

* [`lib/common/sst/drra.h`](diffhunk://#diff-653de8b9b0fca47f8e66d64020be2f25430efb57b1e721467488bf87a3a5722dR277-R283): Added a `data_buffers` member to the `DRRAResource` class and centralized the initialization of data buffers in its constructor. This ensures all derived classes inherit the same initialization logic.

* [`lib/resources/dpu/sst/dpu.cpp`](diffhunk://#diff-09da09a524933d7e0f526b9f75a2d96f1f4a469ea5a1cb4453b7c1c6edc84c91L14-R14): Removed the `setup` method in the `DPU` class, as data buffer initialization is now handled in the base class.

* [`lib/resources/dpu/sst/dpu.h`](diffhunk://#diff-c9cdd0bfc3a1ee32aa140da1681d6ad3face6b3f669f4a6f13ad4ab26975c9ccL51): Removed the `data_buffers` member from the `DPU` class, as it is now inherited from the `DRRAResource` base class.

* [`lib/resources/dpu_2cycle_mac/sst/dpu_2cycle_mac.cpp`](diffhunk://#diff-81ceb7e6f94a16889148ecec5ca836aa0fd7edd010571db9a72288b8eea00ff3L14-R14): Removed the `setup` method in the `DPU2CycleMac` class, as data buffer initialization is now handled in the base class.

* [`lib/resources/dpu_2cycle_mac/sst/dpu_2cycle_mac.h`](diffhunk://#diff-0159e6fc38cc71dcfd985ef0d17d38bb9f71019a8b19cc82c5c945aa0e35d48bL54): Removed the `data_buffers` member from the `DPU2CycleMac` class, as it is now inherited from the `DRRAResource` base class.

### Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Tested locally
- Tested in this PR workflow run

**Test Configuration**:

- OS: Ubuntu 22.04
- Vesyla version: _v4.4.1_

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
