### PR TITLE
feat(sst): updated the sst models to use different io_links for input and output buffers

### DIFF
--- a/lib/common/sst/drra.h
+++ b/lib/common/sst/drra.h
@@ -310,6 +310,18 @@ public:
     sst_assert(data_links.size() == resource_size, CALL_INFO, -1,
                "Data links size mismatch");
 
+    // Configure IO links
+    if (has_io_input_connection) {
+      if (isPortConnected("io_input_port")) {
+        io_input_link = configureLink("io_input_port");
+      }
+    }
+    if (has_io_output_connection) {
+      if (isPortConnected("io_output_port")) {
+        io_output_link = configureLink("io_output_port");
+      }
+    }
+
     // Write to trace file
     trace_file.open(trace_name, std::ios::app);
     trace_file << "{\"name\": \"thread_name\", \"ph\": \"M\", \"pid\": 0, "
@@ -549,6 +561,8 @@ protected:
   // Links
   std::vector<Link *> controller_links;
   std::vector<Link *> data_links;
+  Link *io_input_link = nullptr;
+  Link *io_output_link = nullptr;
 
   // Activation
   std::map<uint32_t, bool> active_ports;

--- a/lib/resources/iosram_both/sst/iosram_both.cpp
+++ b/lib/resources/iosram_both/sst/iosram_both.cpp
@@ -55,9 +55,6 @@ IOSRAMBoth::IOSRAMBoth(SST::ComponentId_t id, SST::Params &params)
     backend = new SST::MemHierarchy::Backend::BackingMalloc(sizeBytes);
   }
   out.output("Created backing store (type: %s)\n", backingType.c_str());
-
-  // IO port
-  io_link = configureLink("io_port", access_time);
 }
 
 void IOSRAMBoth::init(unsigned int phase) {
@@ -246,7 +243,7 @@ void IOSRAMBoth::readFromIO() {
         out.output("Sending read request to IO (addr=%d, size=%dbits)\n",
                    sram_read_from_io_address_buffer, io_data_width);
 
-        io_link->send(readReq);
+        io_input_link->send(readReq);
       });
 }
 
@@ -263,7 +260,7 @@ void IOSRAMBoth::writeToIO() {
         IOWriteRequest *writeReq = new IOWriteRequest();
         writeReq->address = sram_write_to_io_address_buffer;
         writeReq->data = to_io_data_buffer;
-        io_link->send(writeReq);
+        io_output_link->send(writeReq);
 
         out.output(
             "Sending write request to IO (addr=%d, size=%dbits, data=%s)\n",
@@ -278,7 +275,7 @@ void IOSRAMBoth::writeToSRAM() {
       "dsu_write_to_sram_" + std::to_string(current_event_number), 8, [this] {
         // Check if the IO responded
         IOReadResponse *ioReadResponse =
-            dynamic_cast<IOReadResponse *>(io_link->recv());
+            dynamic_cast<IOReadResponse *>(io_input_link->recv());
         if (ioReadResponse) {
           out.output("Received read response from IO (addr=%d, size=%dbits, "
                      "data=%s)\n",

--- a/lib/resources/iosram_both/sst/iosram_both.h
+++ b/lib/resources/iosram_both/sst/iosram_both.h
@@ -38,7 +38,6 @@ public:
   /* Element Library Ports */
   static std::vector<SST::ElementInfoPort> getComponentPorts() {
     auto ports = DRRAResource::getBasePorts();
-    ports.push_back({"io_port", "Link to input or output buffer"});
     return ports;
   }
   SST_ELI_DOCUMENT_PORTS(getComponentPorts())
@@ -83,7 +82,6 @@ private:
     ReadBulk = 7
   };
 
-  SST::Link *io_link = nullptr;
   SST::Link *self_link = nullptr;
   int64_t sram_read_from_io_address_buffer = -1;
   int64_t sram_read_from_io_initial_addr = -1;

--- a/lib/resources/iosram_btm/sst/iosram_btm.cpp
+++ b/lib/resources/iosram_btm/sst/iosram_btm.cpp
@@ -57,9 +57,6 @@ IOSRAMBottom::IOSRAMBottom(SST::ComponentId_t id, SST::Params &params)
     backend = new SST::MemHierarchy::Backend::BackingMalloc(sizeBytes);
   }
   out.output("Created backing store (type: %s)\n", backingType.c_str());
-
-  // IO port
-  io_link = configureLink("io_port", access_time);
 }
 
 void IOSRAMBottom::init(unsigned int phase) {
@@ -250,7 +247,7 @@ void IOSRAMBottom::readFromIO() {
         out.output("Sending read request to IO (addr=%d, size=%dbits)\n",
                    sram_read_from_io_address_buffer, io_data_width);
 
-        io_link->send(readReq);
+        io_input_link->send(readReq);
       });
 }
 
@@ -267,7 +264,7 @@ void IOSRAMBottom::writeToIO() {
         IOWriteRequest *writeReq = new IOWriteRequest();
         writeReq->address = sram_write_to_io_address_buffer;
         writeReq->data = to_io_data_buffer;
-        io_link->send(writeReq);
+        io_output_link->send(writeReq);
 
         out.output(
             "Sending write request to IO (addr=%d, size=%dbits, data=%s)\n",
@@ -282,7 +279,7 @@ void IOSRAMBottom::writeToSRAM() {
       "dsu_write_to_sram_" + std::to_string(current_event_number), 8, [this] {
         // Check if the IO responded
         IOReadResponse *ioReadResponse =
-            dynamic_cast<IOReadResponse *>(io_link->recv());
+            dynamic_cast<IOReadResponse *>(io_input_link->recv());
         if (ioReadResponse) {
           out.output("Received read response from IO (addr=%d, size=%dbits, "
                      "data=%s)\n",

--- a/lib/resources/iosram_btm/sst/iosram_btm.h
+++ b/lib/resources/iosram_btm/sst/iosram_btm.h
@@ -83,7 +83,6 @@ private:
     ReadBulk = 7
   };
 
-  SST::Link *io_link = nullptr;
   SST::Link *self_link = nullptr;
   int64_t sram_read_from_io_address_buffer = -1;
   int64_t sram_read_from_io_initial_addr = -1;

--- a/lib/resources/iosram_btm/sst/iosram_btm.h
+++ b/lib/resources/iosram_btm/sst/iosram_btm.h
@@ -38,7 +38,6 @@ public:
   /* Element Library Ports */
   static std::vector<SST::ElementInfoPort> getComponentPorts() {
     auto ports = DRRAResource::getBasePorts();
-    ports.push_back({"io_port", "Link to input or output buffer"});
     return ports;
   }
   SST_ELI_DOCUMENT_PORTS(getComponentPorts())

--- a/lib/resources/iosram_top/sst/iosram_top.cpp
+++ b/lib/resources/iosram_top/sst/iosram_top.cpp
@@ -57,9 +57,6 @@ IOSRAMTop::IOSRAMTop(SST::ComponentId_t id, SST::Params &params)
     backend = new SST::MemHierarchy::Backend::BackingMalloc(sizeBytes);
   }
   out.output("Created backing store (type: %s)\n", backingType.c_str());
-
-  // IO port
-  io_link = configureLink("io_port", access_time);
 }
 
 void IOSRAMTop::init(unsigned int phase) {
@@ -250,7 +247,7 @@ void IOSRAMTop::readFromIO() {
         out.output("Sending read request to IO (addr=%d, size=%dbits)\n",
                    sram_read_from_io_address_buffer, io_data_width);
 
-        io_link->send(readReq);
+        io_input_link->send(readReq);
       });
 }
 
@@ -267,7 +264,7 @@ void IOSRAMTop::writeToIO() {
         IOWriteRequest *writeReq = new IOWriteRequest();
         writeReq->address = sram_write_to_io_address_buffer;
         writeReq->data = to_io_data_buffer;
-        io_link->send(writeReq);
+        io_output_link->send(writeReq);
 
         out.output(
             "Sending write request to IO (addr=%d, size=%dbits, data=%s)\n",
@@ -282,7 +279,7 @@ void IOSRAMTop::writeToSRAM() {
       "dsu_write_to_sram_" + std::to_string(current_event_number), 8, [this] {
         // Check if the IO responded
         IOReadResponse *ioReadResponse =
-            dynamic_cast<IOReadResponse *>(io_link->recv());
+            dynamic_cast<IOReadResponse *>(io_input_link->recv());
         if (ioReadResponse) {
           out.output("Received read response from IO (addr=%d, size=%dbits, "
                      "data=%s)\n",

--- a/lib/resources/iosram_top/sst/iosram_top.h
+++ b/lib/resources/iosram_top/sst/iosram_top.h
@@ -83,7 +83,6 @@ private:
     ReadBulk = 7
   };
 
-  SST::Link *io_link = nullptr;
   SST::Link *self_link = nullptr;
   int64_t sram_read_from_io_address_buffer = -1;
   int64_t sram_read_from_io_initial_addr = -1;

--- a/lib/resources/iosram_top/sst/iosram_top.h
+++ b/lib/resources/iosram_top/sst/iosram_top.h
@@ -38,7 +38,6 @@ public:
   /* Element Library Ports */
   static std::vector<SST::ElementInfoPort> getComponentPorts() {
     auto ports = DRRAResource::getBasePorts();
-    ports.push_back({"io_port", "Link to input or output buffer"});
     return ports;
   }
   SST_ELI_DOCUMENT_PORTS(getComponentPorts())


### PR DESCRIPTION
# feat(sst): updated the sst models to use different io_links for input and output buffers

## Description

This pull request refactors the handling of IO links across multiple classes by replacing the single `io_link` with separate `io_input_link` and `io_output_link` for resources to be able to use both IO buffers.

See https://github.com/silagokth/vesyla/pull/105.

Documentation PR: _link to the documentation PR, if documentation update is needed_

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- The automatic tests will not PASS in this PR as it is interdependent with https://github.com/silagokth/vesyla/pull/105.

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules