### PR TITLE
feat(ci): added weekly workflow; based run-tests on using the latest vesyla release

### DIFF
--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: [modelsim, vesyla, bender, sst]
     steps:
       - name: Download vesyla
-        uses: actions/download-artifact@v5
+        uses: robinraju/release_downloader@v1
         with:
-          path: $GITHUB_WORKSPACE/bin/
-          name: vesyla
+          out-file-path: bin
+          fileName: vesyla
           repository: silagokth/vesyla
 
       - name: Download library

--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -18,6 +18,7 @@ jobs:
           out-file-path: bin
           fileName: vesyla
           repository: silagokth/vesyla
+          latest: true
 
       - name: Download library
         uses: actions/download-artifact@v5

--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [modelsim, vesyla, bender, sst]
     steps:
       - name: Download vesyla
-        uses: robinraju/release_downloader@v1
+        uses: robinraju/release-downloader@v1
         with:
           out-file-path: bin
           fileName: vesyla

--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -12,8 +12,15 @@ jobs:
   run-tests:
     runs-on: [modelsim, vesyla, bender, sst]
     steps:
+      - name: Download vesyla
+        uses: actions/download-artifact@v5
+        with:
+          path: $GITHUB_WORKSPACE/bin/
+          name: vesyla
+          repository: silagokth/vesyla
+
       - name: Download library
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: library
 
@@ -54,6 +61,8 @@ jobs:
           source .venv/bin/activate
           pip install -r requirements.txt
           export VESYLA_SUITE_PATH_COMPONENTS=$(readlink -e ../library)
+          export GITHUB_PATH=$(readlink -e ../bin/vesyla):$GITHUB_PATH
+          vesyla --version
           vesyla testcase generate -d ./testcases
           ./run.sh
 

--- a/.github/workflows/ci-weekly-build.yml
+++ b/.github/workflows/ci-weekly-build.yml
@@ -1,0 +1,36 @@
+name: master build
+
+on:
+  # trigger on any push on master
+  push:
+    branches:
+      - master
+  # trigger weekly
+  schedule:
+    - cron: '0 3 * * 1' # every monday at 3am
+  workflow_dispatch:
+
+jobs:
+  ci-sst-install:
+    name: SST Install
+    uses: ./.github/workflows/ci-sst-install.yml
+    secrets: inherit
+
+  ci-build-library-sst-off:
+    name: Build DRRA Library without SST
+    uses: ./.github/workflows/ci-build-library-sst-off.yml
+    secrets: inherit
+
+  ci-build-library:
+    name: Build DRRA Library
+    uses: ./.github/workflows/ci-build-library.yml
+    needs: ci-sst-install
+    secrets: inherit
+
+  ci-run-tests:
+    name: Run DRRA Tests
+    uses: ./.github/workflows/ci-run-tests.yml
+    needs: ci-build-library
+    secrets: inherit
+    with:
+      branch: ${{ needs.ci-build-library.outputs.branch }}

--- a/.github/workflows/ci-weekly-build.yml
+++ b/.github/workflows/ci-weekly-build.yml
@@ -9,7 +9,6 @@ on:
   schedule:
     - cron: '0 3 * * 1' # every monday at 3am
   workflow_dispatch:
-  pull_request:
 
 jobs:
   ci-sst-install:

--- a/.github/workflows/ci-weekly-build.yml
+++ b/.github/workflows/ci-weekly-build.yml
@@ -9,6 +9,7 @@ on:
   schedule:
     - cron: '0 3 * * 1' # every monday at 3am
   workflow_dispatch:
+  pull_request:
 
 jobs:
   ci-sst-install:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# DRRA Component Library
+# DRRA Component Library [![Build Status]][actions]
 
-[![](https://github.com/silagokth/drra-components/actions/workflows/ci-release.yml/badge.svg)](https://github.com/silagokth/drra-components/actions/workflows/ci-release.yml)
+[Build Status]: https://github.com/silagokth/drra-components/actions/workflows/ci-weekly-build.yml/badge.svg
+[actions]: https://github.com/silagokth/drra-components/actions/workflows/ci-weekly-build.yml
 
 This repository contains the DRRA component library. The library is a collection of components that can be used to build a DRRA application.
 
@@ -37,6 +38,7 @@ This repository contains the DRRA component library. The library is a collection
     [build]
     rustc-wrapper = "/path/to/sccache"
     ```
+
 ## Cloning the repo
 
 This repo contains submodules.
@@ -47,6 +49,7 @@ git clone --recurse-submodules git@github.com:silagokth/drra-components.git
 ```
 
 Or, if the repo was already cloned:
+
 ```bash
 git submodule update --init
 ```


### PR DESCRIPTION
# feat(ci): update ci workflow to download vesyla and set env variables

## Description

This branch includes two major changes to the CI:
- addition of a weekly build workflow to keep the caches alive and attest of the master branch state
- changed the run-tests workflow so that it downloads the latest vesyla release to run the tests and does not rely on cheddar's vesyla version

Fixes #98 

### Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Tested in this PR workflow
- Tested the master weekly build on trigger: https://github.com/silagokth/drra-components/actions/runs/16831504977

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
