### PR TITLE
fix(common/rtl_pkg): update jinja template to use 'automatic' instead of 'static'

### DIFF
--- a/lib/common/jinja/package.j2
+++ b/lib/common/jinja/package.j2
@@ -15,7 +15,7 @@
       {% endfor %}
   } {{instr.name}}_t;
 
-  function static {{instr.name}}_t unpack_{{instr.name}};
+  function automatic {{instr.name}}_t unpack_{{instr.name}};
       input logic [{{payload_bitwidth - 1}}:0] instr;
       {{instr.name}}_t _{{instr.name}};
       {% set index=payload_bitwidth -1 %}
@@ -30,7 +30,7 @@
       return _{{instr.name}};
   endfunction
 
-  function static logic [{{ payload_bitwidth - 1 }}:0] pack_{{instr.name}};
+  function automatic logic [{{ payload_bitwidth - 1 }}:0] pack_{{instr.name}};
       input {{instr.name}}_t _{{instr.name}};
       logic [{{ payload_bitwidth - 1 }}:0] instr;
 


### PR DESCRIPTION
# fix(common/rtl_pkg): update jinja template to use 'automatic' instead of 'static'

## Description

This pull request updates function declarations in the `lib/common/jinja/package.j2` template to improve compatibility and correctness in SystemVerilog code generation. The main change is switching from `static` to `automatic` for two function types, which affects how variables are allocated and enables reentrancy.

**SystemVerilog function declaration updates:**

* Changed the `unpack_{{instr.name}}` function from `static` to `automatic` to allow for reentrant behavior and stack-based variable allocation.
* Changed the `pack_{{instr.name}}` function from `static` to `automatic` for the same reasons, ensuring better compatibility with modern SystemVerilog practices.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested in this PR workflow
- Tested locally with RTL simulation

**Test Configuration**:

- OS: Ubuntu 24.04
- Vesyla version: _v4.9.1_

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
