### PR TITLE
fix(rtl): moved the logic in cell to sequencer

### DIFF
--- a/lib/cells/cell_btm/rtl/cell_btm.sv.j2
+++ b/lib/cells/cell_btm/rtl/cell_btm.sv.j2
@@ -78,7 +78,8 @@ import {{fingerprint}}_pkg::*;
         .instr_load_addr_out(instr_addr_out),
         .instr_load_hops_out(instr_hops_out),
         .instr_load_en_out(instr_en_out),
-        .ret_out(ret_out)
+        .ret_out(ret_out),
+        .call_out(call_out)
     );
 
     {% for res in resources_list %}

--- a/lib/cells/cell_btm/rtl/cell_btm.sv.j2
+++ b/lib/cells/cell_btm/rtl/cell_btm.sv.j2
@@ -57,33 +57,12 @@ import {{fingerprint}}_pkg::*;
   logic [NUM_SLOTS-1:0][BULK_BITWIDTH-1:0] bulk_data_in;
   logic [NUM_SLOTS-1:0][BULK_BITWIDTH-1:0] bulk_data_out;
 
-  logic controller_call;
-  logic controller_ret, controller_ret_remember, ret_in_remember;
-  assign controller_call = call_in;
-  always_ff @(negedge rst_n or posedge clk) begin
-    if (~rst_n) begin
-      call_out <= 0;
-      controller_ret_remember <= 0;
-      ret_in_remember <= 0;
-    end else begin
-      if (controller_ret) begin
-        controller_ret_remember <= 1;
-      end else if (ret_in) begin
-        ret_in_remember <= 1;
-      end
-      call_out <= call_in;
-    end
-  end
-
-  assign ret_out = controller_ret_remember & ret_in_remember;
-
     // Controller
     `{{controller.name}} controller_inst
     (
         .clk(clk),
         .rst_n(rst_n),
-        .call(controller_call),
-        .ret(controller_ret),
+        .call(call_in),
         {% for i in range(16) %}
         .instr_valid_{{i}}(instr_valid[{{i}}]),
         .instr_{{i}}(instr[{{i}}]),
@@ -98,7 +77,8 @@ import {{fingerprint}}_pkg::*;
         .instr_load_data_out(instr_data_out),
         .instr_load_addr_out(instr_addr_out),
         .instr_load_hops_out(instr_hops_out),
-        .instr_load_en_out(instr_en_out)
+        .instr_load_en_out(instr_en_out),
+        .ret_out(ret_out)
     );
 
     {% for res in resources_list %}

--- a/lib/cells/cell_btm/rtl/cell_btm.sv.j2
+++ b/lib/cells/cell_btm/rtl/cell_btm.sv.j2
@@ -79,6 +79,7 @@ import {{fingerprint}}_pkg::*;
         .instr_load_hops_out(instr_hops_out),
         .instr_load_en_out(instr_en_out),
         .ret_out(ret_out),
+        .ret_in(ret_in),
         .call_out(call_out)
     );
 

--- a/lib/cells/cell_mid/rtl/cell_mid.sv.j2
+++ b/lib/cells/cell_mid/rtl/cell_mid.sv.j2
@@ -78,7 +78,8 @@ import {{fingerprint}}_pkg::*;
         .instr_load_addr_out(instr_addr_out),
         .instr_load_hops_out(instr_hops_out),
         .instr_load_en_out(instr_en_out),
-        .ret_out(ret_out)
+        .ret_out(ret_out),
+        .call_out(call_out)
     );
 
     {% for res in resources_list %}

--- a/lib/cells/cell_mid/rtl/cell_mid.sv.j2
+++ b/lib/cells/cell_mid/rtl/cell_mid.sv.j2
@@ -57,33 +57,12 @@ import {{fingerprint}}_pkg::*;
   logic [NUM_SLOTS-1:0][BULK_BITWIDTH-1:0] bulk_data_in;
   logic [NUM_SLOTS-1:0][BULK_BITWIDTH-1:0] bulk_data_out;
 
-  logic controller_call;
-  logic controller_ret, controller_ret_remember, ret_in_remember;
-  assign controller_call = call_in;
-  always_ff @(negedge rst_n or posedge clk) begin
-    if (~rst_n) begin
-      call_out <= 0;
-      controller_ret_remember <= 0;
-      ret_in_remember <= 0;
-    end else begin
-      if (controller_ret) begin
-        controller_ret_remember <= 1;
-      end else if (ret_in) begin
-        ret_in_remember <= 1;
-      end
-      call_out <= call_in;
-    end
-  end
-
-  assign ret_out = controller_ret_remember & ret_in_remember;
-
     // Controller
     `{{controller.name}} controller_inst
     (
         .clk(clk),
         .rst_n(rst_n),
-        .call(controller_call),
-        .ret(controller_ret),
+        .call(call_in),
         {% for i in range(16) %}
         .instr_valid_{{i}}(instr_valid[{{i}}]),
         .instr_{{i}}(instr[{{i}}]),
@@ -98,7 +77,8 @@ import {{fingerprint}}_pkg::*;
         .instr_load_data_out(instr_data_out),
         .instr_load_addr_out(instr_addr_out),
         .instr_load_hops_out(instr_hops_out),
-        .instr_load_en_out(instr_en_out)
+        .instr_load_en_out(instr_en_out),
+        .ret_out(ret_out)
     );
 
     {% for res in resources_list %}

--- a/lib/cells/cell_mid/rtl/cell_mid.sv.j2
+++ b/lib/cells/cell_mid/rtl/cell_mid.sv.j2
@@ -79,6 +79,7 @@ import {{fingerprint}}_pkg::*;
         .instr_load_hops_out(instr_hops_out),
         .instr_load_en_out(instr_en_out),
         .ret_out(ret_out),
+        .ret_in(ret_in),
         .call_out(call_out)
     );
 

--- a/lib/cells/cell_single_row/rtl/cell_single_row.sv.j2
+++ b/lib/cells/cell_single_row/rtl/cell_single_row.sv.j2
@@ -57,39 +57,12 @@ import {{fingerprint}}_pkg::*;
   logic [NUM_SLOTS-1:0][BULK_BITWIDTH-1:0] bulk_data_in;
   logic [NUM_SLOTS-1:0][BULK_BITWIDTH-1:0] bulk_data_out;
 
-  logic controller_call;
-  logic controller_ret, controller_ret_remember, ret_in_remember;
-  assign controller_call = call_in;
-  always_ff @(negedge rst_n or posedge clk) begin
-    if (~rst_n) begin
-      call_out <= 0;
-      controller_ret_remember <= 0;
-      ret_in_remember <= 0;
-    end else begin
-      if (controller_ret) begin
-        controller_ret_remember <= 1;
-      end else if (ret_in) begin
-        ret_in_remember <= 1;
-      end
-      call_out <= call_in;
-    end
-  end
-
-  assign ret_out = controller_ret_remember & ret_in_remember;
-
-  // Assign the unused_slots to 0
-  {% for slot in unused_slots %}
-  assign word_data_out[{{slot}}] = '0;
-  {% endfor %}
-  assign word_data_out[0] = '0; // switchbox
-
     // Controller
     `{{controller.name}} controller_inst
     (
         .clk(clk),
         .rst_n(rst_n),
-        .call(controller_call),
-        .ret(controller_ret),
+        .call(call_in),
         {% for i in range(16) %}
         .instr_valid_{{i}}(instr_valid[{{i}}]),
         .instr_{{i}}(instr[{{i}}]),
@@ -104,7 +77,8 @@ import {{fingerprint}}_pkg::*;
         .instr_load_data_out(instr_data_out),
         .instr_load_addr_out(instr_addr_out),
         .instr_load_hops_out(instr_hops_out),
-        .instr_load_en_out(instr_en_out)
+        .instr_load_en_out(instr_en_out),
+        .ret_out(ret_out)
     );
 
     {% for res in resources_list %}

--- a/lib/cells/cell_single_row/rtl/cell_single_row.sv.j2
+++ b/lib/cells/cell_single_row/rtl/cell_single_row.sv.j2
@@ -78,7 +78,8 @@ import {{fingerprint}}_pkg::*;
         .instr_load_addr_out(instr_addr_out),
         .instr_load_hops_out(instr_hops_out),
         .instr_load_en_out(instr_en_out),
-        .ret_out(ret_out)
+        .ret_out(ret_out),
+        .call_out(call_out)
     );
 
     {% for res in resources_list %}

--- a/lib/cells/cell_single_row/rtl/cell_single_row.sv.j2
+++ b/lib/cells/cell_single_row/rtl/cell_single_row.sv.j2
@@ -79,6 +79,7 @@ import {{fingerprint}}_pkg::*;
         .instr_load_hops_out(instr_hops_out),
         .instr_load_en_out(instr_en_out),
         .ret_out(ret_out),
+        .ret_in(ret_in),
         .call_out(call_out)
     );
 

--- a/lib/cells/cell_top/rtl/cell_top.sv.j2
+++ b/lib/cells/cell_top/rtl/cell_top.sv.j2
@@ -78,7 +78,8 @@ import {{fingerprint}}_pkg::*;
         .instr_load_addr_out(instr_addr_out),
         .instr_load_hops_out(instr_hops_out),
         .instr_load_en_out(instr_en_out),
-        .ret_out(ret_out)
+        .ret_out(ret_out),
+        .call_out(call_out)
     );
 
     {% for res in resources_list %}

--- a/lib/cells/cell_top/rtl/cell_top.sv.j2
+++ b/lib/cells/cell_top/rtl/cell_top.sv.j2
@@ -57,33 +57,12 @@ import {{fingerprint}}_pkg::*;
   logic [NUM_SLOTS-1:0][BULK_BITWIDTH-1:0] bulk_data_in;
   logic [NUM_SLOTS-1:0][BULK_BITWIDTH-1:0] bulk_data_out;
 
-  logic controller_call;
-  logic controller_ret, controller_ret_remember, ret_in_remember;
-  assign controller_call = call_in;
-  always_ff @(negedge rst_n or posedge clk) begin
-    if (~rst_n) begin
-      call_out <= 0;
-      controller_ret_remember <= 0;
-      ret_in_remember <= 0;
-    end else begin
-      if (controller_ret) begin
-        controller_ret_remember <= 1;
-      end else if (ret_in) begin
-        ret_in_remember <= 1;
-      end
-      call_out <= call_in;
-    end
-  end
-
-  assign ret_out = controller_ret_remember & ret_in_remember;
-
     // Controller
     `{{controller.name}} controller_inst
     (
         .clk(clk),
         .rst_n(rst_n),
-        .call(controller_call),
-        .ret(controller_ret),
+        .call(call_in),
         {% for i in range(16) %}
         .instr_valid_{{i}}(instr_valid[{{i}}]),
         .instr_{{i}}(instr[{{i}}]),
@@ -98,7 +77,8 @@ import {{fingerprint}}_pkg::*;
         .instr_load_data_out(instr_data_out),
         .instr_load_addr_out(instr_addr_out),
         .instr_load_hops_out(instr_hops_out),
-        .instr_load_en_out(instr_en_out)
+        .instr_load_en_out(instr_en_out),
+        .ret_out(ret_out)
     );
 
     {% for res in resources_list %}

--- a/lib/cells/cell_top/rtl/cell_top.sv.j2
+++ b/lib/cells/cell_top/rtl/cell_top.sv.j2
@@ -79,6 +79,7 @@ import {{fingerprint}}_pkg::*;
         .instr_load_hops_out(instr_hops_out),
         .instr_load_en_out(instr_en_out),
         .ret_out(ret_out),
+        .ret_in(ret_in),
         .call_out(call_out)
     );
 

--- a/lib/controllers/sequencer/rtl/sequencer.sv.j2
+++ b/lib/controllers/sequencer/rtl/sequencer.sv.j2
@@ -96,6 +96,7 @@ import {{fingerprint}}_pkg::*;
     output logic instr_load_en_out,
 
     output logic ret_out,
+    input logic ret_in,
     output logic call_out
 );
 

--- a/lib/controllers/sequencer/rtl/sequencer.sv.j2
+++ b/lib/controllers/sequencer/rtl/sequencer.sv.j2
@@ -134,18 +134,18 @@ import {{fingerprint}}_pkg::*;
     logic [{{wait_cycle_bitwidth}}-1:0] wait_counter, wait_counter_next; // Cycles remaining in WAIT state
 
     logic ret;
-    logic controller_ret_remember, ret_in_remember;
-    assign ret_out = controller_ret_remember & ret_in_remember;
+    logic controller_ret_reg, ret_in_reg;
+    assign ret_out = controller_ret_reg & ret_in_reg;
     always_ff @(negedge rst_n or posedge clk) begin
         if (~rst_n) begin
             call_out <= 0;
-            controller_ret_remember <= 0;
-            ret_in_remember <= 0;
+            controller_ret_reg <= 0;
+            ret_in_reg <= 0;
         end else begin
             if (ret) begin
-                controller_ret_remember <= 1;
+                controller_ret_reg <= 1;
             end else if (ret_in) begin
-                ret_in_remember <= 1;
+                ret_in_reg <= 1;
             end
             call_out <= call;
         end

--- a/lib/controllers/sequencer/rtl/sequencer.sv.j2
+++ b/lib/controllers/sequencer/rtl/sequencer.sv.j2
@@ -75,7 +75,6 @@ import {{fingerprint}}_pkg::*;
 
     // Call/return handshake with caller
     input  logic call,
-    output logic ret,
 
     // Per-slot resource interface
     {% for i in range(size) %}
@@ -94,7 +93,9 @@ import {{fingerprint}}_pkg::*;
     output logic [INSTR_DATA_WIDTH-1:0] instr_load_data_out,
     output logic [INSTR_ADDR_WIDTH-1:0] instr_load_addr_out,
     output logic [INSTR_HOPS_WIDTH-1:0] instr_load_hops_out,
-    output logic instr_load_en_out
+    output logic instr_load_en_out,
+
+    output logic ret_out
 );
 
     // Scalar registers
@@ -129,6 +130,26 @@ import {{fingerprint}}_pkg::*;
     logic [{{payload_bitwidth - isa.format.instr_slot_bitwidth}}-1:0] payload;              // Payload (bits 23:0)
     logic [$clog2(IRAM_DEPTH)-1:0] pc, pc_next;           // Program counter (0..63)
     logic [{{wait_cycle_bitwidth}}-1:0] wait_counter, wait_counter_next; // Cycles remaining in WAIT state
+
+    logic ret;
+    assign ret_out = controller_ret_remember & ret_in_remember;
+    logic controller_ret_remember, ret_in_remember;
+    always_ff @(negedge rst_n or posedge clk) begin
+        if (~rst_n) begin
+            call_out <= 0;
+            controller_ret_remember <= 0;
+            ret_in_remember <= 0;
+        end else begin
+            if (ret) begin
+                controller_ret_remember <= 1;
+            end else if (ret_in) begin
+                ret_in_remember <= 1;
+            end
+            call_out <= call_in;
+        end
+    end
+
+
 
     // FSM states
     typedef enum logic [1:0] { RESET, IDLE, DECODE, WAIT} state_t;

--- a/lib/controllers/sequencer/rtl/sequencer.sv.j2
+++ b/lib/controllers/sequencer/rtl/sequencer.sv.j2
@@ -95,7 +95,8 @@ import {{fingerprint}}_pkg::*;
     output logic [INSTR_HOPS_WIDTH-1:0] instr_load_hops_out,
     output logic instr_load_en_out,
 
-    output logic ret_out
+    output logic ret_out,
+    output logic call_out
 );
 
     // Scalar registers
@@ -132,8 +133,8 @@ import {{fingerprint}}_pkg::*;
     logic [{{wait_cycle_bitwidth}}-1:0] wait_counter, wait_counter_next; // Cycles remaining in WAIT state
 
     logic ret;
-    assign ret_out = controller_ret_remember & ret_in_remember;
     logic controller_ret_remember, ret_in_remember;
+    assign ret_out = controller_ret_remember & ret_in_remember;
     always_ff @(negedge rst_n or posedge clk) begin
         if (~rst_n) begin
             call_out <= 0;
@@ -145,7 +146,7 @@ import {{fingerprint}}_pkg::*;
             end else if (ret_in) begin
                 ret_in_remember <= 1;
             end
-            call_out <= call_in;
+            call_out <= call;
         end
     end
 


### PR DESCRIPTION
# fix(rtl): moved the logic in cell to sequencer

## Description

This pull request refactors the call/return handshake logic between the cell modules and their controllers, moving the handshake implementation from the cell modules into the controller itself. This change simplifies the cell module code and centralizes the handshake logic, making the design easier to maintain and understand. Additionally, the controller interface is updated to expose new handshake signals.

### Handshake Logic Refactoring

* Removed the call/return handshake logic (`controller_call`, `controller_ret`, `controller_ret_remember`, `ret_in_remember`, and related always_ff block) from the cell modules (`cell_top`, `cell_mid`, `cell_btm`, `cell_single_row`), and delegated this functionality to the controller. [[1]](diffhunk://#diff-f85b5c1ec90581195747a6e625dcfe032d14abaa280bf1acc81b15045fd0b0acL60-R65) [[2]](diffhunk://#diff-2d8de6393ea83e864909905b65c074fe506cc6ca151355d12303f056a15f0fecL60-R65) [[3]](diffhunk://#diff-0aba3edbe46796c3af3eaab0379c3d9b332d67b6065c1fe6fdc18b56739617acL60-R65)
* Updated the instantiation of the controller in each cell module to connect the new handshake ports: `.ret_out(ret_out)`, `.ret_in(ret_in)`, and `.call_out(call_out)`. [[1]](diffhunk://#diff-f85b5c1ec90581195747a6e625dcfe032d14abaa280bf1acc81b15045fd0b0acL101-R83) [[2]](diffhunk://#diff-2d8de6393ea83e864909905b65c074fe506cc6ca151355d12303f056a15f0fecL101-R83) [[3]](diffhunk://#diff-0aba3edbe46796c3af3eaab0379c3d9b332d67b6065c1fe6fdc18b56739617acL107-R83) [[4]](diffhunk://#diff-54f8544cedfc5dc3b065238aa9dd2a061360ab116561bf3e240b8d0ca4731fddL101-R83)

### Controller Interface and Logic Updates

* Modified the controller interface (e.g., `sequencer.sv.j2`) to remove the `ret` output and add new handshake ports: `ret_out`, `ret_in`, and `call_out`. [[1]](diffhunk://#diff-1456ea4d7cb46ffb081b2918719e47a39112b375f61d24972473e222505855faL78) [[2]](diffhunk://#diff-1456ea4d7cb46ffb081b2918719e47a39112b375f61d24972473e222505855faL97-R100)
* Implemented the handshake logic within the controller, including the `controller_ret_remember` and `ret_in_remember` registers, and the always_ff block that manages them. The controller now drives `ret_out` and `call_out` directly.

These changes centralize handshake management in the controller, reduce duplicated logic, and make the cell modules cleaner and easier to follow.

Fixes #105 

### Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- Tested in PR workflow

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
