### PR TITLE
feat(rtl): updated module names in templates to add the component name with the fingerprint

### DIFF
--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -12,13 +12,27 @@ jobs:
   run-tests:
     runs-on: [modelsim, vesyla, bender, sst]
     steps:
+      - name: Clean bin folder
+        run: |
+          rm -rf ${{ github.workspace }}/bin
+
       - name: Download vesyla
         uses: robinraju/release-downloader@v1
         with:
           out-file-path: bin
-          fileName: vesyla
+          fileName: vesyla-*.AppImage
           repository: silagokth/vesyla
           latest: true
+
+      - name: Rename vesyla AppImage
+        run: |
+          set -e
+          file=(${{ github.workspace }}/bin/vesyla-*.AppImage)
+          if [ "${#file[@]}" -ne 1 ]; then
+            echo "Error: Expected exactly one vesyla-*.AppImage file, found ${#file[@]}"
+            exit 1
+          fi
+          cp "${file[0]}" ${{ github.workspace }}/bin/vesyla
 
       - name: Download library
         uses: actions/download-artifact@v5

--- a/lib/cells/cell_btm/rtl/cell_btm.sv.j2
+++ b/lib/cells/cell_btm/rtl/cell_btm.sv.j2
@@ -1,20 +1,20 @@
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 
 {% for key, value in fingerprint_table | items %}
-`define {{key}} {{value}}
-`define {{key}}_pkg {{value}}_pkg
+`define {{key}} {{key}}_{{value}}
+`define {{key}}_pkg {{key}}_{{value}}_pkg
 {% endfor %}
 
 {% if not already_defined %}
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
     {% for p in parameters %}
     parameter {{p}} = {{parameters[p]}};
     {% endfor %}
 endpackage
 
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 (
     input logic clk,
     input logic rst_n,

--- a/lib/cells/cell_mid/rtl/cell_mid.sv.j2
+++ b/lib/cells/cell_mid/rtl/cell_mid.sv.j2
@@ -1,20 +1,20 @@
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 
 {% for key, value in fingerprint_table | items %}
-`define {{key}} {{value}}
-`define {{key}}_pkg {{value}}_pkg
+`define {{key}} {{key}}_{{value}}
+`define {{key}}_pkg {{key}}_{{value}}_pkg
 {% endfor %}
 
 {% if not already_defined %}
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
     {% for p in parameters %}
     parameter {{p}} = {{parameters[p]}};
     {% endfor %}
 endpackage
 
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 (
     input logic clk,
     input logic rst_n,

--- a/lib/cells/cell_single_row/rtl/cell_single_row.sv.j2
+++ b/lib/cells/cell_single_row/rtl/cell_single_row.sv.j2
@@ -1,20 +1,20 @@
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 
 {% for key, value in fingerprint_table | items %}
-`define {{key}} {{value}}
-`define {{key}}_pkg {{value}}_pkg
+`define {{key}} {{key}}_{{value}}
+`define {{key}}_pkg {{key}}_{{value}}_pkg
 {% endfor %}
 
 {% if not already_defined %}
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
     {% for p in parameters %}
     parameter {{p}} = {{parameters[p]}};
     {% endfor %}
 endpackage
 
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 (
     input logic clk,
     input logic rst_n,

--- a/lib/cells/cell_top/rtl/cell_top.sv.j2
+++ b/lib/cells/cell_top/rtl/cell_top.sv.j2
@@ -1,20 +1,20 @@
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 
 {% for key, value in fingerprint_table | items %}
-`define {{key}} {{value}}
-`define {{key}}_pkg {{value}}_pkg
+`define {{key}} {{key}}_{{value}}
+`define {{key}}_pkg {{key}}_{{value}}_pkg
 {% endfor %}
 
 {% if not already_defined %}
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
     {% for p in parameters %}
     parameter {{p}} = {{parameters[p]}};
     {% endfor %}
 endpackage
 
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 (
     input logic clk,
     input logic rst_n,

--- a/lib/controllers/sequencer/rtl/alu.sv.j2
+++ b/lib/controllers/sequencer/rtl/alu.sv.j2
@@ -1,6 +1,6 @@
 // vesyla_template_start module_head
-module {{fingerprint}}_alu
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}_alu
+import {{name}}_{{fingerprint}}_pkg::*;
 {% set calc_mode_bitwidth = (isa.instructions | selectattr('name', 'equalto', 'calc') | map(attribute='segments') | list | first | selectattr('name', 'equalto', 'mode') | list | first).bitwidth %}
 // vesyla_template_end module_head
 (

--- a/lib/controllers/sequencer/rtl/sequencer.sv.j2
+++ b/lib/controllers/sequencer/rtl/sequencer.sv.j2
@@ -1,13 +1,13 @@
 // Auto-generated defines to give the module and package stable names
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 
 {% set calc_mode_bitwidth = (isa.instructions | selectattr('name', 'equalto', 'calc') | map(attribute='segments') | list | first | selectattr('name', 'equalto', 'mode') | list | first).bitwidth %}
 {% set wait_cycle_bitwidth = (isa.instructions | selectattr('name', 'equalto', 'wait') | map(attribute='segments') | list | first | selectattr('name', 'equalto', 'cycle') | list | first).bitwidth %}
 {% set already_defined = false %}
 {% if not already_defined %}
 // Package holds parameter constants and per-instruction pack/unpack helpers
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
     // Templated parameters
     {% for p in parameters %}
     parameter {{p}} = {{parameters[p]}};
@@ -66,8 +66,8 @@ package {{fingerprint}}_pkg;
 endpackage
 
 // Sequencer module: fetch/decode/dispatch micro-instructions to resources
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 (
     // Clock and reset
     input  logic clk,
@@ -347,7 +347,7 @@ import {{fingerprint}}_pkg::*;
       endcase
     end
 
-  {{fingerprint}}_alu alu_inst (
+  {{name}}_{{fingerprint}}_alu alu_inst (
     .in1(calc_op1),
     .in2(calc_op2),
     .mode(calc_mode),

--- a/lib/fabric/rtl/fabric.sv.j2
+++ b/lib/fabric/rtl/fabric.sv.j2
@@ -1,6 +1,6 @@
 {% for key, value in fingerprint_table | items %}
-`define {{key}} {{value}}
-`define {{key}}_pkg {{value}}_pkg
+`define {{key}} {{key}}_{{value}}
+`define {{key}}_pkg {{key}}_{{value}}_pkg
 {% endfor %}
 
 package fabric_pkg;

--- a/lib/resources/dpu/rtl/adder.sv.j2
+++ b/lib/resources/dpu/rtl/adder.sv.j2
@@ -1,6 +1,6 @@
 // vesyla_template_start module_head
-module {{fingerprint}}_adder
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}_adder
+import {{name}}_{{fingerprint}}_pkg::*;
 // vesyla_template_end module_head
 (
     input logic signed [BITWIDTH-1:0] in1,

--- a/lib/resources/dpu/rtl/dpu.sv.j2
+++ b/lib/resources/dpu/rtl/dpu.sv.j2
@@ -1,12 +1,12 @@
 // vesyla_template_start defines
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 // vesyla_template_end defines
 
 // vesyla_template_start module_head
 {% if not already_defined %}
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 // vesyla_template_end module_head
 (
     input  logic clk_0,
@@ -176,14 +176,14 @@ import {{fingerprint}}_pkg::*;
   end
 
   // in future we will use ChipWare blocks for pipelined and such 
-  {{fingerprint}}_adder adder_inst (
+  {{name}}_{{fingerprint}}_adder adder_inst (
       .in1(adder_in0),
       .in2(adder_in1),
       .saturate(1'b1),
       .out(adder_out)
   );
 
-  {{fingerprint}}_multiplier mult_inst (
+  {{name}}_{{fingerprint}}_multiplier mult_inst (
       .in1(mult_in0),
       .in2(mult_in1),
       .saturate(1'b1),

--- a/lib/resources/dpu/rtl/dpu_pkg.sv.j2
+++ b/lib/resources/dpu/rtl/dpu_pkg.sv.j2
@@ -1,5 +1,5 @@
 // vesyla_template_start package_head
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
 // vesyla_template_end package_head
 
   // vesyla_template_start package_macro

--- a/lib/resources/dpu/rtl/multiplier.sv.j2
+++ b/lib/resources/dpu/rtl/multiplier.sv.j2
@@ -1,6 +1,6 @@
 // vesyla_template_start module_head
-module {{fingerprint}}_multiplier
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}_multiplier
+import {{name}}_{{fingerprint}}_pkg::*;
 // vesyla_template_end module_head
 (
     input logic signed [BITWIDTH-1:0] in1,

--- a/lib/resources/dpu_2cycle_mac/rtl/adder.sv.j2
+++ b/lib/resources/dpu_2cycle_mac/rtl/adder.sv.j2
@@ -1,6 +1,6 @@
 // vesyla_template_start module_head
-module {{fingerprint}}_adder
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}_adder
+import {{name}}_{{fingerprint}}_pkg::*;
 // vesyla_template_end module_head
 (
     input logic signed [BITWIDTH-1:0] in1,

--- a/lib/resources/dpu_2cycle_mac/rtl/dpu_2cycle_mac.sv.j2
+++ b/lib/resources/dpu_2cycle_mac/rtl/dpu_2cycle_mac.sv.j2
@@ -1,12 +1,12 @@
 // vesyla_template_start defines
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 // vesyla_template_end defines
 
 // vesyla_template_start module_head
 {% if not already_defined %}
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 // vesyla_template_end module_head
 (
     input  logic clk_0,
@@ -170,14 +170,14 @@ import {{fingerprint}}_pkg::*;
   end
 
   // in future we will use ChipWare blocks for pipelined and such 
-  {{fingerprint}}_adder adder_inst (
+  {{name}}_{{fingerprint}}_adder adder_inst (
       .in1(adder_in0),
       .in2(adder_in1),
       .saturate(1'b1),
       .out(adder_out)
   );
 
-  {{fingerprint}}_multiplier mult_inst (
+  {{name}}_{{fingerprint}}_multiplier mult_inst (
       .in1(mult_in0),
       .in2(mult_in1),
       .saturate(1'b1),

--- a/lib/resources/dpu_2cycle_mac/rtl/dpu_2cycle_mac_pkg.sv.j2
+++ b/lib/resources/dpu_2cycle_mac/rtl/dpu_2cycle_mac_pkg.sv.j2
@@ -1,5 +1,5 @@
 // vesyla_template_start package_head
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
 // vesyla_template_end package_head
 
   // vesyla_template_start package_macro

--- a/lib/resources/dpu_2cycle_mac/rtl/multiplier.sv.j2
+++ b/lib/resources/dpu_2cycle_mac/rtl/multiplier.sv.j2
@@ -1,6 +1,6 @@
 // vesyla_template_start module_head
-module {{fingerprint}}_multiplier
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}_multiplier
+import {{name}}_{{fingerprint}}_pkg::*;
 // vesyla_template_end module_head
 (
     input logic signed [BITWIDTH-1:0] in1,

--- a/lib/resources/iosram_both/rtl/iosram_both.sv.j2
+++ b/lib/resources/iosram_both/rtl/iosram_both.sv.j2
@@ -1,12 +1,12 @@
 // vesyla_template_start defines
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 // vesyla_template_end defines
 
 // vesyla_template_start module_head
 {% if not already_defined %}
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 // vesyla_template_end module_head
 (
     input  logic clk_0,

--- a/lib/resources/iosram_both/rtl/iosram_both_pkg.sv.j2
+++ b/lib/resources/iosram_both/rtl/iosram_both_pkg.sv.j2
@@ -1,5 +1,5 @@
 // vesyla_template_start package_head
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
 // vesyla_template_end package_head
 
   // vesyla_template_start package_macro

--- a/lib/resources/iosram_btm/rtl/iosram_btm.sv.j2
+++ b/lib/resources/iosram_btm/rtl/iosram_btm.sv.j2
@@ -1,12 +1,12 @@
 // vesyla_template_start defines
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 // vesyla_template_end defines
 
 // vesyla_template_start module_head
 {% if not already_defined %}
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 // vesyla_template_end module_head
 (
     input  logic clk_0,

--- a/lib/resources/iosram_btm/rtl/iosram_btm_pkg.sv.j2
+++ b/lib/resources/iosram_btm/rtl/iosram_btm_pkg.sv.j2
@@ -1,5 +1,5 @@
 // vesyla_template_start package_head
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
 // vesyla_template_end package_head
 
   // vesyla_template_start package_macro

--- a/lib/resources/iosram_top/rtl/iosram_top.sv.j2
+++ b/lib/resources/iosram_top/rtl/iosram_top.sv.j2
@@ -1,12 +1,12 @@
 // vesyla_template_start defines
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 // vesyla_template_end defines
 
 // vesyla_template_start module_head
 {% if not already_defined %}
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 // vesyla_template_end module_head
 (
     input  logic clk_0,

--- a/lib/resources/iosram_top/rtl/iosram_top_pkg.sv.j2
+++ b/lib/resources/iosram_top/rtl/iosram_top_pkg.sv.j2
@@ -1,5 +1,5 @@
 // vesyla_template_start package_head
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
 // vesyla_template_end package_head
 
   // vesyla_template_start package_macro

--- a/lib/resources/rf/rtl/rf.sv.j2
+++ b/lib/resources/rf/rtl/rf.sv.j2
@@ -1,12 +1,12 @@
 // vesyla_template_start defines
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 // vesyla_template_end defines
 
 // vesyla_template_start module_head
 {% if not already_defined %}
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 // vesyla_template_end module_head
 (
     input  logic clk_0,

--- a/lib/resources/rf/rtl/rf_pkg.sv.j2
+++ b/lib/resources/rf/rtl/rf_pkg.sv.j2
@@ -1,5 +1,5 @@
 // vesyla_template_start package_head
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
 // vesyla_template_end package_head
 
   // vesyla_template_start package_macro

--- a/lib/resources/swb/rtl/swb.sv.j2
+++ b/lib/resources/swb/rtl/swb.sv.j2
@@ -1,12 +1,12 @@
 // vesyla_template_start defines
-`define {{name}} {{fingerprint}}
-`define {{name}}_pkg {{fingerprint}}_pkg
+`define {{name}} {{name}}_{{fingerprint}}
+`define {{name}}_pkg {{name}}_{{fingerprint}}_pkg
 // vesyla_template_end defines
 
 // vesyla_template_start module_head
 {% if not already_defined %}
-module {{fingerprint}}
-import {{fingerprint}}_pkg::*;
+module {{name}}_{{fingerprint}}
+import {{name}}_{{fingerprint}}_pkg::*;
 // vesyla_template_end module_head
 (
     input  logic clk_0,

--- a/lib/resources/swb/rtl/swb_pkg.sv.j2
+++ b/lib/resources/swb/rtl/swb_pkg.sv.j2
@@ -1,5 +1,5 @@
 // vesyla_template_start package_head
-package {{fingerprint}}_pkg;
+package {{name}}_{{fingerprint}}_pkg;
 // vesyla_template_end package_head
 
   // vesyla_template_start package_macro


### PR DESCRIPTION
# feat(rtl): updated module names in templates to add the component name with the fingerprint

## Description

This pull request updates the naming conventions for generated SystemVerilog modules, packages, and macros across the codebase. The main goal is to ensure that all generated identifiers include both the cell or resource name and its fingerprint, making them more unique and descriptive. This change improves code clarity and helps prevent naming collisions when multiple variants are instantiated.

The most important changes are:

**SystemVerilog Module and Package Naming Consistency:**

* All module, package, and macro names are now generated in the form `{{name}}_{{fingerprint}}`, instead of just `{{fingerprint}}`. This applies to modules, packages, and macro defines throughout the codebase. [[1]](diffhunk://#diff-f85b5c1ec90581195747a6e625dcfe032d14abaa280bf1acc81b15045fd0b0acL1-R17) [[2]](diffhunk://#diff-2d8de6393ea83e864909905b65c074fe506cc6ca151355d12303f056a15f0fecL1-R17) [[3]](diffhunk://#diff-0aba3edbe46796c3af3eaab0379c3d9b332d67b6065c1fe6fdc18b56739617acL1-R17) [[4]](diffhunk://#diff-54f8544cedfc5dc3b065238aa9dd2a061360ab116561bf3e240b8d0ca4731fddL1-R17) [[5]](diffhunk://#diff-1456ea4d7cb46ffb081b2918719e47a39112b375f61d24972473e222505855faL2-R10) [[6]](diffhunk://#diff-1456ea4d7cb46ffb081b2918719e47a39112b375f61d24972473e222505855faL69-R70) [[7]](diffhunk://#diff-0c98b304bd287c820ccbd03f1557bc0400d86231a85c3d54819485c4fe5f52f8L2-R3) [[8]](diffhunk://#diff-e34d200ccf828c998b1c7306448d430be72ca3e64112933063532d17615cf31bL2-R3) [[9]](diffhunk://#diff-54049adb8f699316ffc4bc445c5fa30e1d0efcc93a240c01ac05534d6bdeaeacL2-R9) [[10]](diffhunk://#diff-54049adb8f699316ffc4bc445c5fa30e1d0efcc93a240c01ac05534d6bdeaeacL179-R186) [[11]](diffhunk://#diff-7c4b14194346c1920b4af43f74eaa610453d73826163ddd7ea251dfbe23bfd36L2-R9) [[12]](diffhunk://#diff-7c4b14194346c1920b4af43f74eaa610453d73826163ddd7ea251dfbe23bfd36L173-R180) [[13]](diffhunk://#diff-7840d073d1f261be5c7161cc99b9195ee6fd41a2b52206de2c4d50cb6d3324f8L2-R9) [[14]](diffhunk://#diff-3c2a4f0491c24a0e6c77f520aae1a3a88d732b4520db825659aa010aa571d294L2-R9) [[15]](diffhunk://#diff-1a050c20a29078f7f8773812b08e37ce48ca02730094895328a599de5c17d68aL2-R9) [[16]](diffhunk://#diff-661d0c3510190fc73f937259cfdc291cc46c75c2e3e51c55491f6b5a3b83c79eL2-R3) [[17]](diffhunk://#diff-ca0d4d80c4d995e7f371895e02dd0b40f278f968e114f0d8f1d37c7e084caf5aL2-R2) [[18]](diffhunk://#diff-aabcc63566eca2e6ee440550051b2e8395381bdeadfec754008e09d9a55b3edaL2-R2) [[19]](diffhunk://#diff-3ad101a9f903e0889c44657f9bc82828c7da791f640b513272a1461e55eb5787L2-R3)

**Macro and Define Updates:**

* All macro defines in the form `` `define {{name}} {{fingerprint}} `` are updated to `` `define {{name}} {{name}}_{{fingerprint}} `` to match the new naming scheme. This also applies to all entries in `fingerprint_table`. [[1]](diffhunk://#diff-f85b5c1ec90581195747a6e625dcfe032d14abaa280bf1acc81b15045fd0b0acL1-R17) [[2]](diffhunk://#diff-2d8de6393ea83e864909905b65c074fe506cc6ca151355d12303f056a15f0fecL1-R17) [[3]](diffhunk://#diff-0aba3edbe46796c3af3eaab0379c3d9b332d67b6065c1fe6fdc18b56739617acL1-R17) [[4]](diffhunk://#diff-54f8544cedfc5dc3b065238aa9dd2a061360ab116561bf3e240b8d0ca4731fddL1-R17) [[5]](diffhunk://#diff-1456ea4d7cb46ffb081b2918719e47a39112b375f61d24972473e222505855faL2-R10) [[6]](diffhunk://#diff-54049adb8f699316ffc4bc445c5fa30e1d0efcc93a240c01ac05534d6bdeaeacL2-R9) [[7]](diffhunk://#diff-7c4b14194346c1920b4af43f74eaa610453d73826163ddd7ea251dfbe23bfd36L2-R9) [[8]](diffhunk://#diff-7840d073d1f261be5c7161cc99b9195ee6fd41a2b52206de2c4d50cb6d3324f8L2-R9) [[9]](diffhunk://#diff-3c2a4f0491c24a0e6c77f520aae1a3a88d732b4520db825659aa010aa571d294L2-R9) [[10]](diffhunk://#diff-1a050c20a29078f7f8773812b08e37ce48ca02730094895328a599de5c17d68aL2-R9) [[11]](diffhunk://#diff-3ad101a9f903e0889c44657f9bc82828c7da791f640b513272a1461e55eb5787L2-R3)

**Internal Module Instantiations and Imports:**

* All internal module instantiations and imports are updated to use the new `{{name}}_{{fingerprint}}` and `{{name}}_{{fingerprint}}_pkg` names, ensuring consistency throughout the codebase and avoiding mismatches. [[1]](diffhunk://#diff-1456ea4d7cb46ffb081b2918719e47a39112b375f61d24972473e222505855faL350-R350) [[2]](diffhunk://#diff-54049adb8f699316ffc4bc445c5fa30e1d0efcc93a240c01ac05534d6bdeaeacL179-R186) [[3]](diffhunk://#diff-7c4b14194346c1920b4af43f74eaa610453d73826163ddd7ea251dfbe23bfd36L173-R180) [[4]](diffhunk://#diff-0c98b304bd287c820ccbd03f1557bc0400d86231a85c3d54819485c4fe5f52f8L2-R3) [[5]](diffhunk://#diff-e34d200ccf828c998b1c7306448d430be72ca3e64112933063532d17615cf31bL2-R3) [[6]](diffhunk://#diff-661d0c3510190fc73f937259cfdc291cc46c75c2e3e51c55491f6b5a3b83c79eL2-R3)

**Template and Package File Updates:**

* All affected Jinja2 template files for cells, resources, and controllers are updated to generate the new naming convention. This ensures that future code generation will follow the new scheme automatically. [[1]](diffhunk://#diff-f85b5c1ec90581195747a6e625dcfe032d14abaa280bf1acc81b15045fd0b0acL1-R17) [[2]](diffhunk://#diff-2d8de6393ea83e864909905b65c074fe506cc6ca151355d12303f056a15f0fecL1-R17) [[3]](diffhunk://#diff-0aba3edbe46796c3af3eaab0379c3d9b332d67b6065c1fe6fdc18b56739617acL1-R17) [[4]](diffhunk://#diff-54f8544cedfc5dc3b065238aa9dd2a061360ab116561bf3e240b8d0ca4731fddL1-R17) [[5]](diffhunk://#diff-1456ea4d7cb46ffb081b2918719e47a39112b375f61d24972473e222505855faL2-R10) [[6]](diffhunk://#diff-1456ea4d7cb46ffb081b2918719e47a39112b375f61d24972473e222505855faL69-R70) [[7]](diffhunk://#diff-0c98b304bd287c820ccbd03f1557bc0400d86231a85c3d54819485c4fe5f52f8L2-R3) [[8]](diffhunk://#diff-e34d200ccf828c998b1c7306448d430be72ca3e64112933063532d17615cf31bL2-R3) [[9]](diffhunk://#diff-54049adb8f699316ffc4bc445c5fa30e1d0efcc93a240c01ac05534d6bdeaeacL2-R9) [[10]](diffhunk://#diff-7c4b14194346c1920b4af43f74eaa610453d73826163ddd7ea251dfbe23bfd36L2-R9) [[11]](diffhunk://#diff-7840d073d1f261be5c7161cc99b9195ee6fd41a2b52206de2c4d50cb6d3324f8L2-R9) [[12]](diffhunk://#diff-3c2a4f0491c24a0e6c77f520aae1a3a88d732b4520db825659aa010aa571d294L2-R9) [[13]](diffhunk://#diff-1a050c20a29078f7f8773812b08e37ce48ca02730094895328a599de5c17d68aL2-R9) [[14]](diffhunk://#diff-661d0c3510190fc73f937259cfdc291cc46c75c2e3e51c55491f6b5a3b83c79eL2-R3) [[15]](diffhunk://#diff-ca0d4d80c4d995e7f371895e02dd0b40f278f968e114f0d8f1d37c7e084caf5aL2-R2) [[16]](diffhunk://#diff-aabcc63566eca2e6ee440550051b2e8395381bdeadfec754008e09d9a55b3edaL2-R2) [[17]](diffhunk://#diff-3ad101a9f903e0889c44657f9bc82828c7da791f640b513272a1461e55eb5787L2-R3)

These changes collectively make the generated codebase more robust and easier to work with, especially when dealing with multiple configurations or instantiations.

Fixes #106

### Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Tested locally
- Tested in this PR workflow

**Test Configuration**:

- OS: Fedora 42
- Vesyla version: _v4.9.1_

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
