### PR TITLE
fix(rtl): fixing latch problem in sequencer

### DIFF
--- a/lib/controllers/sequencer/rtl/sequencer.sv.j2
+++ b/lib/controllers/sequencer/rtl/sequencer.sv.j2
@@ -341,6 +341,9 @@ import {{name}}_{{fingerprint}}_pkg::*;
       calc_op1 = '0;
       calc_op2 = '0;
       calc_mode = '0;
+      for (int i = 0; i < NUM_SCALAR_REGS; i++) begin
+        regs_next[i] = 0;
+      end
 
       case (state)
         RESET: begin

--- a/lib/controllers/sequencer/rtl/sequencer.sv.j2
+++ b/lib/controllers/sequencer/rtl/sequencer.sv.j2
@@ -341,9 +341,7 @@ import {{name}}_{{fingerprint}}_pkg::*;
       calc_op1 = '0;
       calc_op2 = '0;
       calc_mode = '0;
-      for (int i = 0; i < NUM_SCALAR_REGS; i++) begin
-        regs_next[i] = 0;
-      end
+      regs_next = regs;
 
       case (state)
         RESET: begin


### PR DESCRIPTION
# [bug(rtl)] Fixing latch problem in sequencer

## Description

There was a latch on regs_next register in sequencer. I have fixed it.
Fixes #[issue number]

### Type of change

_Please delete options that are not relevant._

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran synthesis to test if the latch is fixed.


- OS:
  _Ubuntu 22.04
- Vesyla version: _vX.X.X_

## Checklist

- [ *] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [ *] I have performed a self-review of my code
- [ *] I have commented my code, particularly in hard-to-understand areas
- [ *] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [ *] My changes generate no new warnings
- [ *] I have added tests that prove my fix is effective or that my feature works
- [ *] New and existing unit tests pass locally with my changes
- [ *] Any dependent changes have been merged and published in downstream modules
