### PR TITLE
Change delay_counter initialization on reset

### DIFF
--- a/lib/common/fsm/rtl/fsm.sv
+++ b/lib/common/fsm/rtl/fsm.sv
@@ -20,7 +20,7 @@ module fsm #(
     if (!rst_n) begin
       state <= 0;
       activate_reg <= 0;
-      delay_counter <= fsm_delays[0];
+      delay_counter <= 0;
     end else if (activate && !activate_reg) begin
       activate_reg <= 1;
       delay_counter <= fsm_delays[0];


### PR DESCRIPTION
Initialize delay_counter to 0 on reset instead of fsm_delays[0]. 
Asynchronous reset can't have connections to inputs, only constants
