### PR TITLE
fix(sst): fixed sst timing model and updated build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,12 @@ if(USE_SST)
   # Add DRRA SST shared library
   add_library(drra SHARED)
 
-  set(COMMON_INCLUDE_DIRS ${SST_INCLUDE_DIRS} $ENV{SST_ELEMENTS_HOME}/include
-                          ${CMAKE_CURRENT_SOURCE_DIR}/lib/common/sst/include)
+  set(COMMON_INCLUDE_DIRS
+    ${SST_INCLUDE_DIRS}
+    $ENV{SST_ELEMENTS_HOME}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/common/sst/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/lib/common/sst/timing_model/include
+  )
 
   target_include_directories(drra PUBLIC ${COMMON_INCLUDE_DIRS})
   target_link_libraries(drra PRIVATE drra_sst_utils)

--- a/lib/common/sst/CMakeLists.txt
+++ b/lib/common/sst/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
+add_subdirectory(timing_model)
+
 # Set the project name
 project(drra_sst_utils)
 
@@ -8,4 +10,4 @@ file(GLOB SOURCES src/*.cpp src/*.c)
 add_library(drra_sst_utils STATIC ${SOURCES})
 set_property(TARGET drra_sst_utils PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(drra_sst_utils PRIVATE ./include/)
-
+target_link_libraries(drra_sst_utils PRIVATE drra_timing_model)

--- a/lib/common/sst/include/drra_resource.h
+++ b/lib/common/sst/include/drra_resource.h
@@ -4,7 +4,7 @@
 #include "instructionEvent.h"
 #include "timingModel.h"
 
-#include <cmath>
+#include <algorithm>
 
 #include <sst/core/link.h>
 #include <sst/core/params.h>

--- a/lib/common/sst/timing_model/CMakeLists.txt
+++ b/lib/common/sst/timing_model/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(drra_timing_model)
+
+file(GLOB SOURCES src/*.cpp src/*.c)
+add_library(drra_timing_model STATIC ${SOURCES})
+set_property(TARGET drra_timing_model PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_include_directories(drra_timing_model PRIVATE ./include/)

--- a/lib/common/sst/timing_model/include/timingExpression.h
+++ b/lib/common/sst/timing_model/include/timingExpression.h
@@ -1,3 +1,6 @@
+#pragma once
+
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
@@ -5,12 +8,11 @@
 #include <string>
 #include <vector>
 
-class TimingExpression;
+class TimingState;
 class TimingEvent;
+class TimingOperator;
 class TransitionOperator;
 class RepetitionOperator;
-class TimingState;
-class TimingOperator;
 
 class TimingExpression {
 public:
@@ -20,6 +22,7 @@ public:
   virtual std::string toString() const = 0;
   virtual uint64_t lastEventId() const;
   virtual std::string lastEventName() const;
+  std::shared_ptr<TimingExpression> parent_expression;
 };
 
 class TimingState {
@@ -32,6 +35,7 @@ private:
   std::vector<uint64_t> levels_step;
 
   std::vector<std::shared_ptr<TimingOperator>> operator_queue;
+  std::shared_ptr<TimingExpression> event0;
 
   TimingState &buildRepetition(uint64_t iterations, uint64_t delay);
   TimingState &buildRepetition(uint64_t iterations, uint64_t delay,
@@ -52,7 +56,11 @@ public:
 
   uint64_t getLastScheduledCycle() const;
   void updateLastScheduledCycle(uint64_t cycle);
+  static TimingState createFromEvent(std::shared_ptr<TimingEvent> event);
   static TimingState createFromEvent(const std::string &name);
+  static TimingState
+  createFromExpression(std::shared_ptr<TimingExpression> expression);
+  TimingState &addEvent(std::shared_ptr<TimingEvent> event);
   TimingState &addEvent(const std::string &name, std::function<void()> handler);
   TimingState &addEvent(const std::string &name, uint8_t priority,
                         std::function<void()> handler);
@@ -76,91 +84,8 @@ public:
   void addEventName(const std::string &name);
   std::string toString() const;
 
-  RepetitionOperator getRepetitionOperatorFromLevel(uint64_t level) const;
-};
+  const RepetitionOperator &
+  getRepetitionOperatorFromLevel(uint64_t level) const;
 
-class TimingEvent : public TimingExpression,
-                    public std::enable_shared_from_this<TimingEvent> {
-private:
-  std::string name;
-  uint64_t eventNumber;
-  std::function<void()> handler;
-  uint8_t priority;
-
-public:
-  TimingEvent(const std::string &name, uint64_t eventNumber);
-  uint64_t scheduleEvents(TimingState &state,
-                          uint64_t startCycle) const override;
-  std::string toString() const override;
-  std::string getName() const;
-  uint64_t getEventNumber() const;
-  uint64_t lastEventId() const override;
-  std::string lastEventName() const override;
-  void execute() const;
-  void setHandler(std::function<void()> handler);
-  std::function<void()> getHandler() const;
-
-  void setPriority(uint8_t priority);
-  uint8_t getPriority() const;
-};
-
-class TimingOperator : public TimingExpression {
-public:
-  virtual ~TimingOperator() {}
-};
-
-class TransitionOperator : public TimingOperator {
-private:
-  uint64_t delay;
-  std::string nextEventName;
-  std::function<void()> handler;
-  std::shared_ptr<TimingExpression> from;
-  std::shared_ptr<TimingExpression> to;
-
-public:
-  TransitionOperator(uint64_t delay, std::string nextEventName,
-                     std::function<void()> handler,
-                     std::shared_ptr<TimingExpression> from,
-                     std::shared_ptr<TimingExpression> to);
-
-  uint64_t getDelay() const;
-  std::string getNextEventName() const;
-  std::function<void()> getHandler() const;
-  std::shared_ptr<TimingExpression> getFrom() const;
-  std::shared_ptr<TimingExpression> getTo() const;
-
-  uint64_t scheduleEvents(TimingState &state,
-                          uint64_t startCycle) const override;
-  std::string toString() const override;
-  uint64_t lastEventId() const override;
-  std::string lastEventName() const override;
-};
-
-class RepetitionOperator : public TimingOperator {
-private:
-  uint64_t iterations;
-  uint64_t delay;
-  uint64_t level;
-  uint64_t step;
-  std::shared_ptr<TimingExpression> expression;
-
-public:
-  RepetitionOperator(uint64_t iterations, uint64_t delay, uint64_t level,
-                     uint64_t step,
-                     std::shared_ptr<TimingExpression> expression);
-
-  uint64_t getIterations() const;
-  uint64_t getDelay() const;
-  uint64_t getLevel() const;
-  uint64_t getStep() const;
-  void setIterations(uint64_t iterations) { this->iterations = iterations; }
-  void setDelay(uint64_t delay) { this->delay = delay; }
-  void setStep(uint64_t step) { this->step = step; }
-  std::shared_ptr<TimingExpression> getExpression() const;
-
-  uint64_t scheduleEvents(TimingState &state,
-                          uint64_t startCycle) const override;
-  std::string toString() const override;
-  uint64_t lastEventId() const override;
-  std::string lastEventName() const override;
+  void print(std::ostream &os);
 };

--- a/lib/common/sst/timing_model/include/timingModel.h
+++ b/lib/common/sst/timing_model/include/timingModel.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "timingExpression.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+class TimingState;
+
+class TimingEvent : public TimingExpression,
+                    public std::enable_shared_from_this<TimingEvent> {
+private:
+  std::string name;
+  uint64_t eventNumber;
+  std::function<void()> handler;
+  uint8_t priority;
+
+public:
+  TimingEvent(const std::string &name, uint64_t eventNumber);
+  TimingEvent(const std::string &name, uint64_t eventNumber,
+              std::function<void()> handler, uint8_t priority);
+  uint64_t scheduleEvents(TimingState &state,
+                          uint64_t startCycle) const override;
+  std::string toString() const override;
+  std::string getName() const;
+  uint64_t getEventNumber() const;
+  uint64_t lastEventId() const override;
+  std::string lastEventName() const override;
+  void execute() const;
+  void setHandler(std::function<void()> handler);
+  std::function<void()> getHandler() const;
+
+  void setPriority(uint8_t priority);
+  uint8_t getPriority() const;
+};

--- a/lib/common/sst/timing_model/include/timingOperators.h
+++ b/lib/common/sst/timing_model/include/timingOperators.h
@@ -1,0 +1,70 @@
+#pragma once
+#include "timingExpression.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+class TimingOperator : public TimingExpression {
+public:
+  virtual ~TimingOperator() {}
+};
+
+class TransitionOperator : public TimingOperator {
+private:
+  uint64_t delay;
+  std::string nextEventName;
+  std::function<void()> handler;
+  std::shared_ptr<TimingExpression> from;
+  std::shared_ptr<TimingExpression> to;
+
+public:
+  TransitionOperator(uint64_t delay, std::string nextEventName,
+                     std::function<void()> handler,
+                     std::shared_ptr<TimingExpression> from,
+                     std::shared_ptr<TimingExpression> to);
+
+  uint64_t getDelay() const;
+  std::string getNextEventName() const;
+  std::function<void()> getHandler() const;
+  std::shared_ptr<TimingExpression> getFrom() const;
+  std::shared_ptr<TimingExpression> getTo() const;
+
+  uint64_t scheduleEvents(TimingState &state,
+                          uint64_t startCycle) const override;
+  std::string toString() const override;
+  uint64_t lastEventId() const override;
+  std::string lastEventName() const override;
+
+  // TimingState toTimingState() const;
+};
+
+class RepetitionOperator : public TimingOperator {
+private:
+  uint64_t iterations;
+  uint64_t delay;
+  uint64_t level;
+  uint64_t step;
+  std::shared_ptr<TimingExpression> expression;
+
+public:
+  RepetitionOperator(uint64_t iterations, uint64_t delay, uint64_t level,
+                     uint64_t step,
+                     std::shared_ptr<TimingExpression> expression);
+
+  uint64_t getIterations() const;
+  uint64_t getDelay() const;
+  uint64_t getLevel() const;
+  uint64_t getStep() const;
+  void setIterations(uint64_t iterations) { this->iterations = iterations; }
+  void setDelay(uint64_t delay) { this->delay = delay; }
+  void setStep(uint64_t step) { this->step = step; }
+  std::shared_ptr<TimingExpression> getExpression() const;
+
+  uint64_t scheduleEvents(TimingState &state,
+                          uint64_t startCycle) const override;
+  std::string toString() const override;
+  uint64_t lastEventId() const override;
+  std::string lastEventName() const override;
+};

--- a/lib/common/sst/timing_model/src/timingExpression.cpp
+++ b/lib/common/sst/timing_model/src/timingExpression.cpp
@@ -1,7 +1,10 @@
+#include "timingExpression.h"
 #include "timingModel.h"
+#include "timingOperators.h"
+
 #include <algorithm>
 #include <cstdint>
-#include <stdexcept>
+#include <iostream>
 
 // TimingExpression implementations
 uint64_t TimingExpression::scheduleEvents(TimingState &state,
@@ -19,7 +22,36 @@ TimingState::TimingState() : eventCounter(0), lastScheduledCycle(0) {}
 TimingState::TimingState(std::shared_ptr<TimingExpression> expression)
     : expression(expression), eventCounter(expression->lastEventId() + 1),
       lastScheduledCycle(0) {
-  addEventName(expression->lastEventName());
+  // expression = expression;
+  // eventCounter = 0;
+  // lastScheduledCycle = 0;
+  if (std::dynamic_pointer_cast<TimingEvent>(expression)) {
+    // std::cout << "Adding event name from expression constructor: "
+    //          << std::dynamic_pointer_cast<TimingEvent>(expression)->getName()
+    //          << std::endl;
+    addEventName(std::dynamic_pointer_cast<TimingEvent>(expression)->getName());
+    return;
+  } else if (std::dynamic_pointer_cast<TransitionOperator>(expression)) {
+    // std::cout << "Adding event names from transition operator in expression "
+    //              "constructor"
+    //           << std::endl;
+    auto transition = std::dynamic_pointer_cast<TransitionOperator>(expression);
+    addEventName(transition->getFrom()->lastEventName());
+    addEventName(transition->getTo()->lastEventName());
+    return;
+  } else if (std::dynamic_pointer_cast<RepetitionOperator>(expression)) {
+    // std::cout << "Adding event names from repetition operator in expression "
+    //              "constructor"
+    //           << std::endl;
+    auto repetition = std::dynamic_pointer_cast<RepetitionOperator>(expression);
+    // Recursively add event names from the inner expression
+    TimingState innerState(repetition->getExpression());
+    for (const auto &name : innerState.eventNames) {
+      addEventName(name);
+    }
+    return;
+  }
+  // addEventName(expression->lastEventName());
 }
 
 uint64_t TimingState::getLastScheduledCycle() const {
@@ -34,6 +66,22 @@ TimingState TimingState::createFromEvent(const std::string &name) {
   uint64_t eventCounter = 0;
   auto event = std::make_shared<TimingEvent>(name, eventCounter++);
   return TimingState(std::static_pointer_cast<TimingExpression>(event));
+}
+
+TimingState TimingState::createFromEvent(std::shared_ptr<TimingEvent> event) {
+  uint64_t eventCounter = event->getEventNumber() + 1;
+  return TimingState(std::static_pointer_cast<TimingExpression>(event));
+}
+
+TimingState TimingState::createFromExpression(
+    std::shared_ptr<TimingExpression> expression) {
+  return TimingState(expression);
+}
+
+TimingState &TimingState::addEvent(std::shared_ptr<TimingEvent> event) {
+  addEventName(event->getName());
+  expression = std::static_pointer_cast<TimingExpression>(event);
+  return *this;
 }
 
 TimingState &TimingState::addEvent(const std::string &name,
@@ -69,7 +117,7 @@ TimingState &TimingState::buildTransition(uint64_t delay,
   if (!expression) {
     throw std::runtime_error("Cannot add transition without an event");
   }
-  delay++; // delay is always incremented by 1
+  // delay++; // delay is always incremented by 1
   auto nextEvent = std::make_shared<TimingEvent>(nextEventName, eventCounter++);
   nextEvent->setHandler(handler);
   nextEvent->setPriority(priority);
@@ -175,33 +223,36 @@ TimingState &TimingState::build() {
   }
   auto expression = this->expression;
 
-  // Order operator_queue by putting all transition in beginning
-  uint32_t transition_count = 0;
-  for (uint32_t i = 0; i < operator_queue.size(); i++) {
-    if (std::dynamic_pointer_cast<TransitionOperator>(operator_queue[i])) {
-      if (i != transition_count) {
-        std::swap(operator_queue[i], operator_queue[transition_count]);
-      }
-      transition_count++;
-    }
-  }
+  //// Order operator_queue by putting all transition in beginning
+  // uint32_t transition_count = 0;
+  // for (uint32_t i = 0; i < operator_queue.size(); i++) {
+  //   if (std::dynamic_pointer_cast<TransitionOperator>(operator_queue[i])) {
+  //     if (i != transition_count) {
+  //       std::swap(operator_queue[i], operator_queue[transition_count]);
+  //     }
+  //     transition_count++;
+  //   }
+  // }
 
-  // Order the left repetition operators by level
-  for (uint32_t i = transition_count; i < operator_queue.size(); i++) {
-    for (uint32_t j = i + 1; j < operator_queue.size(); j++) {
-      if (std::dynamic_pointer_cast<RepetitionOperator>(operator_queue[i]) &&
-          std::dynamic_pointer_cast<RepetitionOperator>(operator_queue[j])) {
-        if (std::dynamic_pointer_cast<RepetitionOperator>(operator_queue[i])
-                ->getLevel() >
-            std::dynamic_pointer_cast<RepetitionOperator>(operator_queue[j])
-                ->getLevel()) {
-          std::swap(operator_queue[i], operator_queue[j]);
-        }
-      }
-    }
-  }
+  //// Order the left repetition operators by level
+  // for (uint32_t i = transition_count; i < operator_queue.size(); i++) {
+  //   for (uint32_t j = i + 1; j < operator_queue.size(); j++) {
+  //     if (std::dynamic_pointer_cast<RepetitionOperator>(operator_queue[i]) &&
+  //         std::dynamic_pointer_cast<RepetitionOperator>(operator_queue[j])) {
+  //       if (std::dynamic_pointer_cast<RepetitionOperator>(operator_queue[i])
+  //               ->getLevel() >
+  //           std::dynamic_pointer_cast<RepetitionOperator>(operator_queue[j])
+  //               ->getLevel()) {
+  //         std::swap(operator_queue[i], operator_queue[j]);
+  //       }
+  //     }
+  //   }
+  // }
 
   // Add all operators to the expression
+  // std::cout << operator_queue.size() << " operators to be processed in
+  // build() "
+  //<< std::endl;
   for (auto &op : operator_queue) {
     if (auto transition = std::dynamic_pointer_cast<TransitionOperator>(op)) {
       this->buildTransition(transition->getDelay(),
@@ -217,6 +268,8 @@ TimingState &TimingState::build() {
 
     // Update the timing expression
     expression = this->expression;
+    // std::cout << "Current expression: " << expression->toString() <<
+    // std::endl;
   }
 
   // Schedule events
@@ -274,7 +327,7 @@ void TimingState::addEventName(const std::string &name) {
 
 std::string TimingState::toString() const { return expression->toString(); }
 
-RepetitionOperator
+const RepetitionOperator &
 TimingState::getRepetitionOperatorFromLevel(uint64_t level) const {
   // Find repetition operator with the same level in the operator queue
   for (auto &op : operator_queue) {
@@ -295,128 +348,20 @@ TimingState::getRepetitionOperatorFromLevel(uint64_t level) const {
                            std::to_string(level) + " not found");
 }
 
-// TimingEvent implementations
-TimingEvent::TimingEvent(const std::string &name, uint64_t eventNumber)
-    : name(name), eventNumber(eventNumber) {}
+void TimingState::print(std::ostream &os) {
+  uint64_t lastCycle = getLastScheduledCycle();
 
-uint64_t TimingEvent::scheduleEvents(TimingState &state,
-                                     uint64_t startCycle) const {
-  state.scheduleEvent(shared_from_this(), startCycle);
-  state.updateLastScheduledCycle(startCycle);
-  return startCycle;
-}
-
-std::string TimingEvent::toString() const {
-  return "e" + std::to_string(eventNumber);
-}
-
-std::string TimingEvent::getName() const { return name; }
-
-uint64_t TimingEvent::getEventNumber() const { return eventNumber; }
-
-uint64_t TimingEvent::lastEventId() const { return eventNumber; }
-
-std::string TimingEvent::lastEventName() const { return name; }
-
-void TimingEvent::execute() const {
-  if (handler) {
-    handler();
-  }
-}
-
-void TimingEvent::setHandler(std::function<void()> handler) {
-  this->handler = handler;
-}
-
-std::function<void()> TimingEvent::getHandler() const { return handler; }
-
-void TimingEvent::setPriority(uint8_t priority) { this->priority = priority; }
-
-uint8_t TimingEvent::getPriority() const { return priority; }
-
-// TransitionOperator implementations
-TransitionOperator::TransitionOperator(uint64_t delay,
-                                       std::string nextEventName,
-                                       std::function<void()> handler,
-                                       std::shared_ptr<TimingExpression> from,
-                                       std::shared_ptr<TimingExpression> to)
-    : delay(delay), nextEventName(nextEventName), handler(handler), from(from),
-      to(to) {}
-
-uint64_t TransitionOperator::scheduleEvents(TimingState &state,
-                                            uint64_t startCycle) const {
-  uint64_t fromCycle = from->scheduleEvents(state, startCycle);
-  uint64_t toCycle = to->scheduleEvents(state, fromCycle + delay);
-  return toCycle;
-}
-
-std::string TransitionOperator::toString() const {
-  return "T<" + std::to_string(delay) + ">(" + from->toString() + "," +
-         to->toString() + ")";
-}
-
-uint64_t TransitionOperator::lastEventId() const { return to->lastEventId(); }
-
-std::string TransitionOperator::lastEventName() const {
-  return to->lastEventName();
-}
-
-uint64_t TransitionOperator::getDelay() const { return delay; }
-
-std::string TransitionOperator::getNextEventName() const {
-  return nextEventName;
-}
-
-std::function<void()> TransitionOperator::getHandler() const { return handler; }
-
-std::shared_ptr<TimingExpression> TransitionOperator::getFrom() const {
-  return from;
-}
-
-std::shared_ptr<TimingExpression> TransitionOperator::getTo() const {
-  return to;
-}
-
-// RepetitionOperator implementations
-RepetitionOperator::RepetitionOperator(
-    uint64_t iterations, uint64_t delay, uint64_t level, uint64_t step,
-    std::shared_ptr<TimingExpression> expression)
-    : iterations(iterations), delay(delay), level(level), step(step),
-      expression(expression) {}
-
-uint64_t RepetitionOperator::scheduleEvents(TimingState &state,
-                                            uint64_t startCycle) const {
-  uint64_t lastCycle = startCycle;
-  for (uint64_t i = 0; i < iterations; i++) {
-    lastCycle = expression->scheduleEvents(state, lastCycle);
-    if (i < iterations - 1) {
-      lastCycle += delay;
+  for (uint64_t cycle = 0; cycle <= lastCycle + 1; cycle++) {
+    auto events = getEventsForCycle(cycle);
+    if (events.size() == 0) {
+      os << cycle << ": ---\n";
+    } else {
+      os << cycle << ": ";
+      for (const auto &event : events) {
+        event->execute();
+        os << " (" << event->getName() << ")";
+      }
+      os << "\n";
     }
   }
-  return lastCycle;
-}
-
-std::string RepetitionOperator::toString() const {
-  return "R<" + std::to_string(iterations) + "," + std::to_string(delay) +
-         ">(" + expression->toString() + ")";
-}
-
-uint64_t RepetitionOperator::lastEventId() const {
-  return expression->lastEventId();
-}
-
-std::string RepetitionOperator::lastEventName() const {
-  return expression->lastEventName();
-}
-
-uint64_t RepetitionOperator::getIterations() const { return iterations; }
-
-uint64_t RepetitionOperator::getDelay() const { return delay; }
-
-uint64_t RepetitionOperator::getLevel() const { return level; }
-
-uint64_t RepetitionOperator::getStep() const { return step; }
-
-std::shared_ptr<TimingExpression> RepetitionOperator::getExpression() const {
-  return expression;
 }

--- a/lib/common/sst/timing_model/src/timingModel.cpp
+++ b/lib/common/sst/timing_model/src/timingModel.cpp
@@ -1,0 +1,48 @@
+#include "timingModel.h"
+#include <cstdint>
+#include <functional>
+#include <string>
+
+// TimingEvent implementations
+TimingEvent::TimingEvent(const std::string &name, uint64_t eventNumber)
+    : name(name), eventNumber(eventNumber) {}
+
+TimingEvent::TimingEvent(const std::string &name, uint64_t eventNumber,
+                         std::function<void()> handler, uint8_t priority)
+    : name(name), eventNumber(eventNumber), handler(handler),
+      priority(priority) {}
+
+uint64_t TimingEvent::scheduleEvents(TimingState &state,
+                                     uint64_t startCycle) const {
+  state.scheduleEvent(shared_from_this(), startCycle);
+  state.updateLastScheduledCycle(startCycle);
+  return startCycle;
+}
+
+std::string TimingEvent::toString() const {
+  return "e" + std::to_string(eventNumber);
+}
+
+std::string TimingEvent::getName() const { return name; }
+
+uint64_t TimingEvent::getEventNumber() const { return eventNumber; }
+
+uint64_t TimingEvent::lastEventId() const { return eventNumber; }
+
+std::string TimingEvent::lastEventName() const { return name; }
+
+void TimingEvent::execute() const {
+  if (handler) {
+    handler();
+  }
+}
+
+void TimingEvent::setHandler(std::function<void()> handler) {
+  this->handler = handler;
+}
+
+std::function<void()> TimingEvent::getHandler() const { return handler; }
+
+void TimingEvent::setPriority(uint8_t priority) { this->priority = priority; }
+
+uint8_t TimingEvent::getPriority() const { return priority; }

--- a/lib/common/sst/timing_model/src/timingOperators.cpp
+++ b/lib/common/sst/timing_model/src/timingOperators.cpp
@@ -1,0 +1,98 @@
+#include "timingOperators.h"
+#include "timingExpression.h"
+#include <cstdint>
+#include <functional>
+// #include <iostream>
+#include <memory>
+#include <string>
+TransitionOperator::TransitionOperator(uint64_t delay,
+                                       std::string nextEventName,
+                                       std::function<void()> handler,
+                                       std::shared_ptr<TimingExpression> from,
+                                       std::shared_ptr<TimingExpression> to)
+    : delay(delay), nextEventName(nextEventName), handler(handler), from(from),
+      to(to) {
+  // from->parent_expression =
+  //     std::static_pointer_cast<TimingExpression>(shared_from_this());
+}
+
+uint64_t TransitionOperator::scheduleEvents(TimingState &state,
+                                            uint64_t startCycle) const {
+  // std::cout << "Scheduling TransitionOperator: " << toString() << std::endl;
+  uint64_t fromCycle = from->scheduleEvents(state, startCycle);
+  uint64_t toCycle = to->scheduleEvents(state, fromCycle + delay + 1);
+  // std::cout << "TransitionOperator scheduled at cycle " << toCycle <<
+  // std::endl;
+  return toCycle;
+}
+
+std::string TransitionOperator::toString() const {
+  return "T<" + std::to_string(delay) + ">(" + from->toString() + "," +
+         to->toString() + ")";
+}
+
+uint64_t TransitionOperator::lastEventId() const { return to->lastEventId(); }
+
+std::string TransitionOperator::lastEventName() const {
+  return to->lastEventName();
+}
+
+uint64_t TransitionOperator::getDelay() const { return delay; }
+
+std::string TransitionOperator::getNextEventName() const {
+  return nextEventName;
+}
+
+std::function<void()> TransitionOperator::getHandler() const { return handler; }
+
+std::shared_ptr<TimingExpression> TransitionOperator::getFrom() const {
+  return from;
+}
+
+std::shared_ptr<TimingExpression> TransitionOperator::getTo() const {
+  return to;
+}
+
+// RepetitionOperator implementations
+RepetitionOperator::RepetitionOperator(
+    uint64_t iterations, uint64_t delay, uint64_t level, uint64_t step,
+    std::shared_ptr<TimingExpression> expression)
+    : iterations(iterations), delay(delay), level(level), step(step),
+      expression(expression) {}
+
+uint64_t RepetitionOperator::scheduleEvents(TimingState &state,
+                                            uint64_t startCycle) const {
+  // std::cout << "Scheduling RepetitionOperator: " << toString() << std::endl;
+  uint64_t lastCycle = startCycle;
+  for (uint64_t i = 0; i < iterations; i++) {
+    lastCycle = expression->scheduleEvents(state, lastCycle);
+    if (i < iterations - 1)
+      lastCycle += delay;
+  }
+  return lastCycle;
+}
+
+std::string RepetitionOperator::toString() const {
+  return "R<" + std::to_string(iterations) + "," + std::to_string(delay) +
+         ">(" + expression->toString() + ")";
+}
+
+uint64_t RepetitionOperator::lastEventId() const {
+  return expression->lastEventId();
+}
+
+std::string RepetitionOperator::lastEventName() const {
+  return expression->lastEventName();
+}
+
+uint64_t RepetitionOperator::getIterations() const { return iterations; }
+
+uint64_t RepetitionOperator::getDelay() const { return delay; }
+
+uint64_t RepetitionOperator::getLevel() const { return level; }
+
+uint64_t RepetitionOperator::getStep() const { return step; }
+
+std::shared_ptr<TimingExpression> RepetitionOperator::getExpression() const {
+  return expression;
+}

--- a/lib/resources/dpu/sst/dpu.cpp
+++ b/lib/resources/dpu/sst/dpu.cpp
@@ -1,6 +1,7 @@
 #include "dpu.h"
 #include "dataEvent.h"
 #include "dpu_operations.h"
+#include "timingOperators.h"
 
 using namespace SST;
 

--- a/lib/resources/dpu_2cycle_mac/sst/dpu_2cycle_mac.cpp
+++ b/lib/resources/dpu_2cycle_mac/sst/dpu_2cycle_mac.cpp
@@ -1,6 +1,7 @@
 #include "dpu_2cycle_mac.h"
 #include "dataEvent.h"
 #include "dpu_operations.h"
+#include "timingOperators.h"
 
 using namespace SST;
 

--- a/lib/resources/iosram_both/sst/iosram_both.cpp
+++ b/lib/resources/iosram_both/sst/iosram_both.cpp
@@ -3,6 +3,7 @@
 #include "dataEvent.h"
 #include "ioEvents.h"
 #include "iosram_both_pkg.h"
+#include "timingOperators.h"
 
 using namespace SST;
 

--- a/lib/resources/iosram_btm/sst/iosram_btm.cpp
+++ b/lib/resources/iosram_btm/sst/iosram_btm.cpp
@@ -3,6 +3,7 @@
 #include "dataEvent.h"
 #include "ioEvents.h"
 #include "iosram_btm_pkg.h"
+#include "timingOperators.h"
 
 using namespace SST;
 

--- a/lib/resources/iosram_top/sst/iosram_top.cpp
+++ b/lib/resources/iosram_top/sst/iosram_top.cpp
@@ -3,6 +3,7 @@
 #include "dataEvent.h"
 #include "ioEvents.h"
 #include "iosram_top_pkg.h"
+#include "timingOperators.h"
 
 using namespace SST;
 

--- a/lib/resources/rf/sst/rf.cpp
+++ b/lib/resources/rf/sst/rf.cpp
@@ -1,5 +1,6 @@
 #include "rf.h"
 #include "dataEvent.h"
+#include "timingOperators.h"
 
 using namespace SST;
 

--- a/lib/resources/swb/sst/swb.cpp
+++ b/lib/resources/swb/sst/swb.cpp
@@ -1,6 +1,7 @@
 #include "swb.h"
 #include "dataEvent.h"
 #include "swb_pkg.h"
+#include "timingOperators.h"
 
 using namespace SST;
 

--- a/sst_tests/CMakeLists.txt
+++ b/sst_tests/CMakeLists.txt
@@ -24,6 +24,12 @@ foreach(source ${SOURCES})
   get_filename_component(EXECUTABLE_NAME ${source} NAME_WE)
   add_executable(${EXECUTABLE_NAME} ${source})
   target_include_directories(${EXECUTABLE_NAME} PRIVATE ${COMMON_INCLUDE_DIRS})
-  target_link_libraries(${EXECUTABLE_NAME} PRIVATE GTest::GTest GTest::Main
-                                                   drra_sst_utils)
+  target_link_libraries(
+    ${EXECUTABLE_NAME}
+    PRIVATE
+    GTest::GTest
+    GTest::Main
+    drra_sst_utils
+    drra_timing_model
+  )
 endforeach()

--- a/sst_tests/test_timingModel.cpp
+++ b/sst_tests/test_timingModel.cpp
@@ -1,4 +1,6 @@
 #include "timingModel.h"
+#include "timingOperators.h"
+#include <ctime>
 #include <gtest/gtest.h>
 
 // Initialize static member
@@ -54,7 +56,7 @@ TEST(TimingModelTest, FindEventByNameTest) {
 
 TEST(TimingModelTest, TransitionOperator) {
   TimingState state = TimingState::createFromEvent("Event1");
-  state.addTransition(4, "Event2", [] {}); // delay is 5 cycles (4 + 1)
+  state.addTransition(4, "Event2", [] {}); // delay is 4 cycles between events
   state.build();                           // Schedule events
 
   // Check Event1 at cycle 0
@@ -130,12 +132,12 @@ TEST(TimingModelTest, ComplexPatternToString) {
   state.addRepetition(1, 9, 1, 0);
   state.build();
 
-  EXPECT_EQ(state.toString(), "R<2,10>(R<2,10>(T<3>(T<2>(e0,e1),e2)))");
+  EXPECT_EQ(state.toString(), "R<2,10>(T<2>(R<2,10>(T<1>(e0,e1)),e2))");
 }
 
 TEST(TimingModelTest, RepetitionTesting) {
   TimingState state = TimingState::createFromEvent("e0");
-  state.addTransition(1, "e1", [] {});
+  state.addTransition(2, "e1", [] {});
   state.addRepetition(1, 3);
   state.addRepetition(1, 1, 1, 0);
   state.build();
@@ -152,7 +154,49 @@ TEST(TimingModelTest, AdjustRepetition) {
   EXPECT_EQ(state.toString(), "R<3,3>(e0)");
 }
 
+void manual_test() {
+  TimingState state = TimingState();
+  auto e0 = std::make_shared<TimingEvent>(
+      "e0", 1,
+      [] {
+        std::cout << "e0 " << std::time(0);
+        // sleep(1);
+      },
+      5);
+  auto r_e0 = std::make_shared<RepetitionOperator>(4, 1, 0, 0, e0);
+  auto e1 = std::make_shared<TimingEvent>(
+      "e1", 2,
+      [] {
+        std::cout << "e1 " << std::time(0);
+        // sleep(1);
+      },
+      5);
+  auto r_e1 = std::make_shared<RepetitionOperator>(4, 1, 2, 2, e1);
+  auto t_e0_e1 =
+      std::make_shared<TransitionOperator>(4, "e1", [] {}, r_e0, r_e1);
+  TimingState state_from_expr = TimingState::createFromExpression(t_e0_e1);
+  std::cout << "State from expression:\n" << state_from_expr.toString() << "\n";
+
+  // state.addEvent("e0", [] {
+  //   std::cout << std::time(0);
+  //   // sleep(1);
+  // });
+  // state.addRepetition(3, 0); // 0 1 2 3
+  //// state.addRepetition(1, 0, 1, 0); // 0 1
+
+  // state.addTransition(0, "e1", [] { std::cout << "t " << std::time(0); });
+  // state.addRepetition(3, 1, 2, 2);
+  //// state.addRepetition(1, 0, 3, 2);
+
+  state = state_from_expr;
+  state.build();
+
+  std::cout << state.toString() << "\n";
+  state.print(std::cout);
+}
+
 int main(int argc, char **argv) {
+  // manual_test();
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This pull request introduces a significant refactor to the timing model subsystem, splitting the timing model code into dedicated files and directories, and updating the build system accordingly. The changes improve modularity, maintainability, and clarity of the codebase by separating key classes into their own headers and source files, and by updating CMake build logic to support the new structure.

**Build system and project structure updates:**

* Added the `timing_model` subdirectory to the build process and created a new `drra_timing_model` static library for timing model code in `lib/common/sst/timing_model` (`lib/common/sst/CMakeLists.txt`, `lib/common/sst/timing_model/CMakeLists.txt`) [[1]](diffhunk://#diff-60e19b269e2c5117c65396d14f9a0c0446f82fcc89675ee15fab392aaa889b34R3-R4) [[2]](diffhunk://#diff-3f94472329d3c597b168bc98df0d88b9996f523df465e6b0c250a8e088da7485R1-R8).
* Updated `drra_sst_utils` to link against `drra_timing_model` and included new timing model headers in the build (`lib/common/sst/CMakeLists.txt`, `CMakeLists.txt`) [[1]](diffhunk://#diff-60e19b269e2c5117c65396d14f9a0c0446f82fcc89675ee15fab392aaa889b34L11-R13) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL45-R50).

**Timing model code refactor and modularization:**

* Split the timing model classes (`TimingEvent`, `TimingOperator`, `TransitionOperator`, `RepetitionOperator`) into separate header files: `timingExpression.h`, `timingModel.h`, and `timingOperators.h`, with appropriate class declarations and implementations moved to their respective files (`lib/common/sst/timing_model/include/timingExpression.h`, `lib/common/sst/timing_model/include/timingModel.h`, `lib/common/sst/timing_model/include/timingOperators.h`) [[1]](diffhunk://#diff-5c8509fc1a79f6d628e938872de35d83b259feca15d08a2dc91387f85c82e341R1-L13) [[2]](diffhunk://#diff-dd50bc3efa1e2df9e4c6b1c53a26c9ba419d310965fdb51ab58ca80a89f4ed9cR1-R37) [[3]](diffhunk://#diff-215abba1860d11f4078dc8d392231938d5ff34022800dba4476d9c911ae918f8R1-R70).
* Renamed and moved the original `timingModel.h` and `timingModel.cpp` to `timingExpression.h` and `timingExpression.cpp`, separating concerns and improving code clarity (`lib/common/sst/timing_model/include/timingExpression.h`, `lib/common/sst/timing_model/src/timingExpression.cpp`) [[1]](diffhunk://#diff-5c8509fc1a79f6d628e938872de35d83b259feca15d08a2dc91387f85c82e341R1-L13) [[2]](diffhunk://#diff-c73f96dac9507f6a92978c1943ee34817432c48b55ffde1899126ecc6ed7439dR1-R7).

**TimingState enhancements and API improvements:**

* Added new methods to `TimingState` for creating from events or expressions, and for adding events, improving flexibility for constructing timing state objects (`lib/common/sst/timing_model/include/timingExpression.h`, `lib/common/sst/timing_model/src/timingExpression.cpp`) [[1]](diffhunk://#diff-5c8509fc1a79f6d628e938872de35d83b259feca15d08a2dc91387f85c82e341R59-R63) [[2]](diffhunk://#diff-c73f96dac9507f6a92978c1943ee34817432c48b55ffde1899126ecc6ed7439dR71-R86).
* Modified the implementation of `getRepetitionOperatorFromLevel` to return a reference instead of a value, improving efficiency and correctness (`lib/common/sst/timing_model/include/timingExpression.h`, `lib/common/sst/timing_model/src/timingExpression.cpp`) [[1]](diffhunk://#diff-5c8509fc1a79f6d628e938872de35d83b259feca15d08a2dc91387f85c82e341L79-R90) [[2]](diffhunk://#diff-c73f96dac9507f6a92978c1943ee34817432c48b55ffde1899126ecc6ed7439dL277-R330).

**Minor code and dependency cleanups:**

* Replaced `<cmath>` with `<algorithm>` in `drra_resource.h` for more appropriate standard library usage (`lib/common/sst/include/drra_resource.h`).
* Commented out unnecessary code in `TimingState::build()` to simplify operator queue ordering logic (`lib/common/sst/timing_model/src/timingExpression.cpp`).

These changes collectively modernize and modularize the timing model subsystem, making future development and maintenance easier.