### PR TITLE
chore: update CODEOWNERS to consolidate file ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,8 @@
 *.vhd.j2 @jagjordi @NosratiNooshin @SabaYs
 *.vhd @jagjordi @NosratiNooshin @SabaYs
 Bender.yml @jagjordi @NosratiNooshin @SabaYs
-*.h @PaulDelestrac @herenvarno
-*.hpp @PaulDelestrac @herenvarno
-*.c @PaulDelestrac @herenvarno
-*.cpp @PaulDelestrac @herenvarno 
-*.rs @PaulDelestrac @herenvarno
+*.h @PaulDelestrac
+*.hpp @PaulDelestrac
+*.c @PaulDelestrac
+*.cpp @PaulDelestrac
+*.rs @PaulDelestrac


### PR DESCRIPTION
This pull request updates the `.github/CODEOWNERS` file to adjust code ownership assignments. The main change is the removal of `@herenvarno` as a code owner for several file types, leaving `@PaulDelestrac` as the sole owner.

Ownership changes:

* Removed `@herenvarno` as a code owner for `*.h`, `*.hpp`, `*.c`, `*.cpp`, and `*.rs` files, assigning sole ownership to `@PaulDelestrac`. (.github/CODEOWNERS)