### PR TITLE
fix(sst/iosram): fix trans instruction for iosram; fixed address guard bug

### DIFF
--- a/lib/common/sst/include/drra_agu.h
+++ b/lib/common/sst/include/drra_agu.h
@@ -7,6 +7,7 @@ private:
   std::unique_ptr<TimingState> timing_state = nullptr;
 
   std::vector<TimingState> lanes;
+  std::vector<uint64_t> lane_initial_addresses;
   size_t current_lane_index = 0;
   size_t current_trans_index = 0;
   uint64_t current_rep_level = 0;

--- a/lib/common/sst/src/drra_agu.cpp
+++ b/lib/common/sst/src/drra_agu.cpp
@@ -37,6 +37,7 @@ DRRA_AGU &DRRA_AGU::addEvent(const std::string &name,
   if (auto lane = getLaneAtIndex(current_lane_index)) {
     auto expr = lane->getExpression();
     lane->addEvent(name, handler, priority);
+    lane_initial_addresses.push_back(initial_address);
     current_rep_level = 0;
     current_lane_index++;
   } else {
@@ -208,6 +209,7 @@ DRRA_AGU &DRRA_AGU::build() {
   if (std::getenv("VESYLA_DEBUG"))
     std::cout << "Timing state expression: "
               << timing_state->getExpression()->toString() << "\n";
+  timing_state->setEventInitialAddresses(lane_initial_addresses);
   timing_state->build();
   if (std::getenv("VESYLA_DEBUG"))
     std::cout << "Timing state built successfully\n";
@@ -223,6 +225,7 @@ DRRA_AGU &DRRA_AGU::reset() {
                                : "none")
               << "\n";
   lanes.clear();
+  lane_initial_addresses.clear();
   timing_state = nullptr;
   current_lane_index = 0;
   current_trans_index = 0;
@@ -241,11 +244,7 @@ int64_t DRRA_AGU::getAddressForCycle(uint64_t cycle) {
   if (isEmpty())
     return -1;
 
-  int64_t address = timing_state->getAddressForCycle(cycle);
-  if (address != -1)
-    address += initial_address;
-
-  return address;
+  return timing_state->getAddressForCycle(cycle);
 }
 
 uint64_t DRRA_AGU::getLastScheduledCycle() {

--- a/lib/common/sst/src/drra_resource.cpp
+++ b/lib/common/sst/src/drra_resource.cpp
@@ -199,7 +199,11 @@ void DRRAResource::executeScheduledEventsForCycle(Cycle_t currentSSTCycle) {
       if (isPortActive(port.first)) { // if port is active
         auto events =
             getPortEventsForCycle(port.first, getPortActiveCycle(port.first));
-
+        if (std::getenv("VESYLA_DEBUG"))
+          out.output(
+              "Port %d has %lu events for cycle %lu (port active cycle %lu)\n",
+              port.first, events.size(), currentSSTCycle / 10,
+              getPortActiveCycle(port.first));
         // add events to the list
         for (auto event : events) {
           events_for_cycle.push_back(event);

--- a/lib/common/sst/timing_model/include/timingExpression.h
+++ b/lib/common/sst/timing_model/include/timingExpression.h
@@ -28,14 +28,15 @@ public:
 class TimingState {
 private:
   std::shared_ptr<TimingExpression> expression;
-  uint64_t eventCounter;
-  uint64_t lastScheduledCycle;
+  uint64_t eventCounter = 0;
+  uint64_t lastScheduledCycle = 0;
   std::map<uint64_t, uint64_t> generatedAddresses;
   std::vector<uint64_t> levels_current_iteration;
   std::vector<uint64_t> levels_total_iterations;
   std::vector<uint64_t> levels_step;
 
   std::vector<std::shared_ptr<TimingExpression>> operator_queue;
+  std::vector<uint64_t> eventInitialAddresses;
 
   TimingState &buildRepetition(uint64_t iterations, uint64_t delay);
   TimingState &buildRepetition(uint64_t iterations, uint64_t delay,
@@ -95,6 +96,7 @@ public:
 
   RepetitionOperator getRepetitionOperatorFromLevel(uint64_t level) const;
   int64_t getAddressForCycle(uint64_t cycle);
+  void setEventInitialAddresses(const std::vector<uint64_t> &addresses);
   void copyLevelData(const TimingState &other);
   const std::vector<uint64_t> &getLevelsStep() const;
   const std::vector<uint64_t> &getLevelsTotalIterations() const;

--- a/lib/common/sst/timing_model/src/timingExpression.cpp
+++ b/lib/common/sst/timing_model/src/timingExpression.cpp
@@ -28,6 +28,7 @@ TimingState::TimingState(const TimingState &other)
     : expression(other.expression), eventCounter(other.eventCounter),
       lastScheduledCycle(other.lastScheduledCycle),
       eventNames(other.eventNames), operator_queue(other.operator_queue),
+      eventInitialAddresses(other.eventInitialAddresses),
       scheduledEvents(other.scheduledEvents),
       generatedAddresses(other.generatedAddresses),
       levels_current_iteration(other.levels_current_iteration),
@@ -115,6 +116,7 @@ TimingState &TimingState::operator=(const TimingState &other) {
     lastScheduledCycle = other.lastScheduledCycle;
     eventNames = other.eventNames;
     operator_queue = other.operator_queue;
+    eventInitialAddresses = other.eventInitialAddresses;
     scheduledEvents = other.scheduledEvents;
     generatedAddresses = other.generatedAddresses;
     levels_current_iteration = other.levels_current_iteration;
@@ -421,12 +423,16 @@ TimingState &TimingState::build() {
   for (auto &op : operator_queue) {
     if (auto event = std::dynamic_pointer_cast<TimingEvent>(op)) {
       expressions.push_back(std::static_pointer_cast<TimingExpression>(event));
-      // First address for the event is 0
+      // First address for the event uses per-event initial address if available
       current_event_id++;
       events_addresses[current_event_id] = std::map<uint64_t, uint64_t>();
-      events_addresses[current_event_id][0] = 0;
+      uint64_t init_addr =
+          (current_event_id < (int64_t)eventInitialAddresses.size())
+              ? eventInitialAddresses[current_event_id]
+              : 0;
+      events_addresses[current_event_id][0] = init_addr;
       events_last_cycle[current_event_id] = 0;
-      events_last_address[current_event_id] = 0;
+      events_last_address[current_event_id] = init_addr;
     } else if (auto transition =
                    std::dynamic_pointer_cast<TransitionOperator>(op)) {
       if (std::getenv("VESYLA_DEBUG"))
@@ -571,6 +577,38 @@ TimingState &TimingState::build() {
   }
 
   // Schedule events
+  if (std::getenv("VESYLA_DEBUG")) {
+    // Print type of expression (TimingEvent, TransitionOperator,
+    // RepetitionOperator)
+    if (std::dynamic_pointer_cast<TimingEvent>(expression)) {
+      std::cout << "Expression is a TimingEvent: "
+                << std::dynamic_pointer_cast<TimingEvent>(expression)->getName()
+                << std::endl;
+    } else if (std::dynamic_pointer_cast<TransitionOperator>(expression)) {
+      std::cout << "Expression is a TransitionOperator (next event: "
+                << std::dynamic_pointer_cast<TransitionOperator>(expression)
+                       ->getNextEventName()
+                << ")" << std::endl;
+    } else if (std::dynamic_pointer_cast<RepetitionOperator>(expression)) {
+      std::cout << "Expression is a RepetitionOperator (level: "
+                << std::dynamic_pointer_cast<RepetitionOperator>(expression)
+                       ->getLevel()
+                << ", iterations: "
+                << std::dynamic_pointer_cast<RepetitionOperator>(expression)
+                       ->getIterations()
+                << ", delay: "
+                << std::dynamic_pointer_cast<RepetitionOperator>(expression)
+                       ->getDelay()
+                << ", step: "
+                << std::dynamic_pointer_cast<RepetitionOperator>(expression)
+                       ->getStep()
+                << ")" << std::endl;
+    } else {
+      std::cout << "Expression is an unknown type" << std::endl;
+    }
+    std::cout << "Scheduling events for expression: " << expression->toString()
+              << std::endl;
+  }
   updateLastScheduledCycle(
       this->expression->scheduleEvents(*this, lastScheduledCycle));
   lastScheduledCycle = addresses.rbegin()->first;
@@ -602,6 +640,17 @@ void TimingState::scheduleEvent(std::shared_ptr<const TimingEvent> event,
 std::set<std::shared_ptr<const TimingEvent>>
 TimingState::getEventsForCycle(uint64_t cycle) {
   auto eventsIterator = scheduledEvents.find(cycle);
+  if (std::getenv("VESYLA_DEBUG"))
+    std::cout << "Getting events for cycle " << cycle << " in scheduledEvents ("
+              << scheduledEvents.size() << " entries)" << std::endl;
+  // print all cycles where these is an event scheduled for debugging
+  if (std::getenv("VESYLA_DEBUG")) {
+    std::cout << "Scheduled events cycles:" << std::endl;
+    for (const auto &entry : scheduledEvents) {
+      std::cout << " Cycle " << entry.first << " -> " << entry.second.size()
+                << " events" << std::endl;
+    }
+  }
   if (eventsIterator != scheduledEvents.end()) {
     return eventsIterator->second;
   }
@@ -668,6 +717,11 @@ int64_t TimingState::getAddressForCycle(uint64_t cycle) {
     address = it->second;
   }
   return address;
+}
+
+void TimingState::setEventInitialAddresses(
+    const std::vector<uint64_t> &addresses) {
+  eventInitialAddresses = addresses;
 }
 
 void TimingState::copyLevelData(const TimingState &other) {

--- a/lib/resources/dpu/compile_util/src/main.rs
+++ b/lib/resources/dpu/compile_util/src/main.rs
@@ -33,7 +33,6 @@ use serde_json::json;
  *
  */
 use serde_json::Value;
-use std::collections::HashMap;
 use std::env;
 use std::ops::{Deref, DerefMut};
 
@@ -44,11 +43,8 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_level = [0, 0];
-    let mut current_trans = [0, 0];
-    let mut t: HashMap<i64, String> = HashMap::new();
-    let mut r: HashMap<i64, (String, String)> = HashMap::new();
-    let mut expr = "e0".to_string();
+    let mut segments: Vec<String> = Vec::new();
+    let mut event_counter = 0;
 
     for instr in op.body {
         let instr_segments = instr.params;
@@ -57,24 +53,24 @@ fn get_timing_model(op: Op) -> String {
                 // NOTE: DPU instruction does not affect the timing model
             }
             "evt" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
-                current_level[port] = 0;
-                current_trans[port] = 0;
+                segments.push(format!("e{}", event_counter));
+                event_counter += 1;
             }
             "rep" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let iter = instr_segments.get_value("iter");
                 let delay = instr_segments.get_value("delay");
-                r.insert(current_level[port], (iter.to_string(), delay.to_string()));
-                current_level[port] += 1;
+                if let Some(last) = segments.last_mut() {
+                    *last = format!("R<{},{}>({})", iter, delay, last);
+                }
             }
             "repx" => {}
             "trans" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let delay = instr_segments.get_value("delay");
-                t.insert(current_trans[port], delay);
-                current_level[port] = 0;
-                current_trans[port] += 1;
+                if segments.len() >= 2 {
+                    let right = segments.pop().unwrap();
+                    let left = segments.pop().unwrap();
+                    segments.push(format!("T<{}>({},{})", delay, left, right));
+                }
             }
             _ => {
                 panic!("Unknown instruction kind: {}", instr.kind);
@@ -82,31 +78,7 @@ fn get_timing_model(op: Op) -> String {
         }
     }
 
-    let mut event_counter = 1;
-    let mut t_keys: Vec<_> = t.keys().cloned().collect();
-    t_keys.sort();
-    for i in t_keys {
-        if let Some(delay) = t.get(&i) {
-            if delay != "0" {
-                expr = format!("T<{}>({}, e{})", delay, expr, event_counter);
-                event_counter += 1;
-            } else {
-                break;
-            }
-        }
-    }
-
-    let mut r_keys: Vec<_> = r.keys().cloned().collect();
-    r_keys.sort();
-    for i in r_keys {
-        if let Some(values) = r.get(&i) {
-            expr = format!("R<{},{}>({})", values.0, values.1, expr);
-        } else {
-            break;
-        }
-    }
-
-    expr
+    segments.pop().unwrap_or_else(|| "e0".to_string())
 }
 
 fn reshape_instr(op: Op) -> Op {
@@ -392,5 +364,63 @@ fn main() {
             std::fs::write(output_file, serde_json::to_string(&reshaped_json).unwrap()).unwrap();
         }
         _ => panic!("Unknown subcommand: {}", subcommand),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_instr(kind: &str, params: Vec<(&str, &str)>) -> Instr {
+        Instr {
+            kind: kind.to_string(),
+            id: "".to_string(),
+            params: InstrSegments::new(
+                params
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
+        }
+    }
+
+    fn make_op(body: Vec<Instr>) -> Op {
+        Op {
+            kind: "rop".to_string(),
+            id: "test".to_string(),
+            row: 0,
+            col: 0,
+            slot: 0,
+            port: 0,
+            body,
+        }
+    }
+
+    #[test]
+    fn test_transit_with_two_repeats() {
+        let op = make_op(vec![
+            make_instr("evt", vec![("option", "0")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "0"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("evt", vec![("option", "1")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "1"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("trans", vec![("delay", "0")]),
+        ]);
+        assert_eq!(get_timing_model(op), "T<0>(R<4,0>(e0),R<4,0>(e1))");
     }
 }

--- a/lib/resources/iosram_both/compile_util/src/main.rs
+++ b/lib/resources/iosram_both/compile_util/src/main.rs
@@ -44,8 +44,8 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_rep = 0;
-    let mut current_trans = 0;
+    let mut current_level = [0, 0];
+    let mut current_trans = [0, 0];
     let mut t: HashMap<i64, String> = HashMap::new();
     let mut r: HashMap<i64, (String, String)> = HashMap::new();
     let mut expr = "e0".to_string();
@@ -54,21 +54,24 @@ fn get_timing_model(op: Op) -> String {
         let instr_segments = instr.params;
         match instr.kind.as_str() {
             "dsu" => {
-                current_rep = 0;
-                current_trans = 0;
+                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
+                current_level[port] = 0;
+                current_trans[port] = 0;
             }
             "rep" => {
+                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let iter = instr_segments.get_value("iter");
                 let delay = instr_segments.get_value("delay");
-                r.insert(current_rep, (iter.to_string(), delay.to_string()));
-                current_rep += 1;
+                r.insert(current_level[port], (iter.to_string(), delay.to_string()));
+                current_level[port] += 1;
             }
             "repx" => {}
-            "fsm" => {
+            "trans" => {
+                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let delay = instr_segments.get_value("delay");
-                t.insert(current_trans, delay);
-                current_rep = 0;
-                current_trans += 1;
+                t.insert(current_trans[port], delay);
+                current_level[port] = 0;
+                current_trans[port] += 1;
             }
             _ => {
                 panic!("Unknown instruction kind: {}", instr.kind);

--- a/lib/resources/iosram_both/compile_util/src/main.rs
+++ b/lib/resources/iosram_both/compile_util/src/main.rs
@@ -44,8 +44,8 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_level = [0, 0];
-    let mut current_trans = [0, 0];
+    let mut current_level = [0; 4];
+    let mut current_trans = [0; 4];
     let mut t: HashMap<i64, String> = HashMap::new();
     let mut r: HashMap<i64, (String, String)> = HashMap::new();
     let mut expr = "e0".to_string();

--- a/lib/resources/iosram_both/compile_util/src/main.rs
+++ b/lib/resources/iosram_both/compile_util/src/main.rs
@@ -33,7 +33,6 @@ use serde_json::json;
  *
  */
 use serde_json::Value;
-use std::collections::HashMap;
 use std::env;
 use std::ops::{Deref, DerefMut};
 
@@ -44,34 +43,31 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_level = [0; 4];
-    let mut current_trans = [0; 4];
-    let mut t: HashMap<i64, String> = HashMap::new();
-    let mut r: HashMap<i64, (String, String)> = HashMap::new();
-    let mut expr = "e0".to_string();
+    let mut segments: Vec<String> = Vec::new();
+    let mut event_counter = 0;
 
     for instr in op.body {
         let instr_segments = instr.params;
         match instr.kind.as_str() {
             "dsu" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
-                current_level[port] = 0;
-                current_trans[port] = 0;
+                segments.push(format!("e{}", event_counter));
+                event_counter += 1;
             }
             "rep" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let iter = instr_segments.get_value("iter");
                 let delay = instr_segments.get_value("delay");
-                r.insert(current_level[port], (iter.to_string(), delay.to_string()));
-                current_level[port] += 1;
+                if let Some(last) = segments.last_mut() {
+                    *last = format!("R<{},{}>({})", iter, delay, last);
+                }
             }
             "repx" => {}
             "trans" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let delay = instr_segments.get_value("delay");
-                t.insert(current_trans[port], delay);
-                current_level[port] = 0;
-                current_trans[port] += 1;
+                if segments.len() >= 2 {
+                    let right = segments.pop().unwrap();
+                    let left = segments.pop().unwrap();
+                    segments.push(format!("T<{}>({},{})", delay, left, right));
+                }
             }
             _ => {
                 panic!("Unknown instruction kind: {}", instr.kind);
@@ -79,31 +75,7 @@ fn get_timing_model(op: Op) -> String {
         }
     }
 
-    let mut event_counter = 1;
-    let mut t_keys: Vec<_> = t.keys().cloned().collect();
-    t_keys.sort();
-    for i in t_keys {
-        if let Some(delay) = t.get(&i) {
-            if delay != "0" {
-                expr = format!("T<{}>({}, e{})", delay, expr, event_counter);
-                event_counter += 1;
-            } else {
-                break;
-            }
-        }
-    }
-
-    let mut r_keys: Vec<_> = r.keys().cloned().collect();
-    r_keys.sort();
-    for i in r_keys {
-        if let Some(values) = r.get(&i) {
-            expr = format!("R<{},{}>({})", values.0, values.1, expr);
-        } else {
-            break;
-        }
-    }
-
-    expr
+    segments.pop().unwrap_or_else(|| "e0".to_string())
 }
 
 fn reshape_instr(op: Op) -> Op {
@@ -388,5 +360,63 @@ fn main() {
             std::fs::write(output_file, serde_json::to_string(&reshaped_json).unwrap()).unwrap();
         }
         _ => panic!("Unknown subcommand: {}", subcommand),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_instr(kind: &str, params: Vec<(&str, &str)>) -> Instr {
+        Instr {
+            kind: kind.to_string(),
+            id: "".to_string(),
+            params: InstrSegments::new(
+                params
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
+        }
+    }
+
+    fn make_op(body: Vec<Instr>) -> Op {
+        Op {
+            kind: "rop".to_string(),
+            id: "test".to_string(),
+            row: 0,
+            col: 0,
+            slot: 0,
+            port: 0,
+            body,
+        }
+    }
+
+    #[test]
+    fn test_transit_with_two_repeats() {
+        let op = make_op(vec![
+            make_instr("dsu", vec![("option", "0"), ("init_addr", "0")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "0"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("dsu", vec![("option", "1"), ("init_addr", "18")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "1"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("trans", vec![("delay", "0")]),
+        ]);
+        assert_eq!(get_timing_model(op), "T<0>(R<4,0>(e0),R<4,0>(e1))");
     }
 }

--- a/lib/resources/iosram_both/sst/iosram_both.cpp
+++ b/lib/resources/iosram_both/sst/iosram_both.cpp
@@ -75,8 +75,10 @@ void Iosram_both::handleActivation(uint32_t slot_id, uint32_t ports) {
 }
 
 void Iosram_both::handleDSU(const IOSRAM_BOTH_PKG::DSUInstruction &instr) {
-  out.output("dsu (slot=%d, init_addr_sd=%d, init_addr=%d, port=%d)\n",
-             instr.slot, instr.init_addr_sd, instr.init_addr, instr.port);
+  out.output("dsu (slot=%d, port=%d, option=%d, init_addr_sd=%d, init_addr=%d, "
+             "port=%d)\n",
+             instr.slot, instr.port, instr.option, instr.init_addr_sd,
+             instr.init_addr);
 
   // Set initial address
   uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
@@ -84,24 +86,69 @@ void Iosram_both::handleDSU(const IOSRAM_BOTH_PKG::DSUInstruction &instr) {
   out.output("Set initial address for port %d to %d\n", port_num,
              instr.init_addr);
 
+  std::string event_name;
   switch (port_num) {
   case DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO:
-    readFromIO();
+    event_name =
+        "dsu_sram_read_from_io_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO);
+          readFromIO();
+        },
+        1);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO:
-    writeToIO();
+    event_name = "dsu_sram_write_to_io_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO);
+          writeToIO();
+        },
+        9);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM:
-    writeToSRAM();
+    event_name = "dsu_io_write_to_sram_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM);
+          writeToSRAM();
+        },
+        8);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM:
-    readFromSRAM();
+    event_name =
+        "dsu_io_read_from_sram_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM);
+          readFromSRAM();
+        },
+        2);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK:
-    writeBulk();
+    event_name = "dsu_write_bulk_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK);
+          writeBulk();
+        },
+        9);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_READ_BULK:
-    readBulk();
+    event_name = "dsu_read_bulk_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK);
+          readBulk();
+        },
+        1);
     break;
 
   default:
@@ -116,27 +163,7 @@ void Iosram_both::handleREP(const IOSRAM_BOTH_PKG::REPInstruction &instr) {
   out.output("rep (slot=%d, port=%d, iter=%d, step=%d, delay=%d)\n", instr.slot,
              instr.port, instr.iter, instr.step, instr.delay);
 
-  uint32_t port_num = 0;
-  auto it = std::find(slot_ids.begin(), slot_ids.end(), instr.slot);
-  if (it != slot_ids.end()) {
-    port_num = std::distance(slot_ids.begin(), it);
-  } else {
-    out.fatal(CALL_INFO, -1, "Slot ID not found\n");
-  }
-  port_num = port_num * 4 + instr.port;
-
-  // // For now, we only support increasing repetition levels (and no skipping)
-  // if (instr.level != port_last_rep_level[port_num] + 1) {
-  //   out.output("port_num = %d\n", port_num);
-  //   out.fatal(
-  //       CALL_INFO, -1,
-  //       "Invalid repetition level (last=%d, curr=%d), instruction: (slot: "
-  //       "%d, port: %d, level: %d, iter: %d, step: %d, delay: %d)\n",
-  //       port_last_rep_level[port_num], instr.level, instr.slot, instr.port,
-  //       instr.level, instr.iter, instr.step, instr.delay);
-  // } else {
-  //   port_last_rep_level[port_num] = instr.level;
-  // }
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
 
   // add repetition to the timing model
   try {
@@ -152,15 +179,7 @@ void Iosram_both::handleREPX(const IOSRAM_BOTH_PKG::REPXInstruction &instr) {
   out.output("repx (slot=%d, port=%d, iter=%d, step=%d, delay=%d)\n",
              instr.slot, instr.port, instr.iter, instr.step, instr.delay);
 
-  uint32_t port_num = 0;
-  auto it = std::find(slot_ids.begin(), slot_ids.end(), instr.slot);
-  if (it != slot_ids.end()) {
-    port_num = std::distance(slot_ids.begin(), it);
-  } else {
-    out.fatal(CALL_INFO, -1, "Slot ID not found\n");
-  }
-  port_num = port_num * 4 + instr.port;
-
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
   auto repetition_op = agus[port_num].getLastRepetitionOperator();
   uint32_t iter = instr.iter
                       << IOSRAM_BOTH_PKG::IOSRAM_BOTH_INSTR_REPX_ITER_BITWIDTH |
@@ -180,61 +199,56 @@ void Iosram_both::handleREPX(const IOSRAM_BOTH_PKG::REPXInstruction &instr) {
   }
 }
 
+void Iosram_both::handleTRANS(const IOSRAM_BOTH_PKG::TRANSInstruction &instr) {
+  out.output("trans (slot=%d, port=%d, delay=%d)\n", instr.slot, instr.port,
+             instr.delay);
+
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
+
+  try {
+    agus[port_num].addTransition(instr.delay);
+    current_event_number++;
+  } catch (const std::exception &e) {
+    out.fatal(CALL_INFO, -1, "Failed to add transition: %s\n", e.what());
+  }
+}
+
 void Iosram_both::readFromIO() {
-  std::string event_name =
-      "dsu_read_from_io_" + std::to_string(current_event_number);
-  // Reading data from the IO to the buffer
-  agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO].addEvent(
-      event_name,
-      [this, event_name] {
-        sram_read_from_io_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO));
+  sram_read_from_io_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO));
 
-        IOReadRequest *readReq = new IOReadRequest();
-        readReq->address = sram_read_from_io_address_buffer;
-        readReq->size = io_data_width / 8;
-        readReq->column_id = cell_coordinates[1];
+  IOReadRequest *readReq = new IOReadRequest();
+  readReq->address = sram_read_from_io_address_buffer;
+  readReq->size = io_data_width / 8;
+  readReq->column_id = cell_coordinates[1];
 
-        out.output("Sending read request to IO (addr=%d, size=%dbits)\n",
-                   sram_read_from_io_address_buffer, io_data_width);
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)sram_read_from_io_address_buffer},
-                       {"size", (int)(io_data_width / 8)}});
+  out.output("Sending read request to IO (addr=%d, size=%dbits)\n",
+             sram_read_from_io_address_buffer, io_data_width);
+  logTraceEvent("iosram_read_from_io", slot_id, true, 'X',
+                {{"address", (int)sram_read_from_io_address_buffer},
+                 {"size", (int)(io_data_width / 8)}});
 
-        io_input_link->send(readReq);
-      },
-      1);
+  io_input_link->send(readReq);
 }
 
 void Iosram_both::writeToIO() {
-  std::string event_name =
-      "dsu_write_to_io_" + std::to_string(current_event_number);
-  // Writing buffer data to the IO
-  agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO].addEvent(
-      event_name,
-      [this, event_name] {
-        sram_write_to_io_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO));
+  sram_write_to_io_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO));
 
-        IOWriteRequest *writeReq = new IOWriteRequest();
-        writeReq->address = sram_write_to_io_address_buffer;
-        writeReq->data = to_io_data_buffer;
-        io_output_link->send(writeReq);
+  IOWriteRequest *writeReq = new IOWriteRequest();
+  writeReq->address = sram_write_to_io_address_buffer;
+  writeReq->data = to_io_data_buffer;
+  io_output_link->send(writeReq);
 
-        out.output(
-            "Sending write request to IO (addr=%d, size=%dbits, data=%s)\n",
-            writeReq->address, writeReq->data.size() * 8,
-            formatRawDataToWords(writeReq->data).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)sram_write_to_io_address_buffer},
-                       {"size", (int)(to_io_data_buffer.size())},
-                       {"data", formatRawDataToWords(to_io_data_buffer)}});
-      },
-      9);
+  out.output("Sending write request to IO (addr=%d, size=%dbits, data=%s)\n",
+             writeReq->address, writeReq->data.size() * 8,
+             formatRawDataToWords(writeReq->data).c_str());
+  logTraceEvent("iosram_write_to_io", slot_id, true, 'X',
+                {{"address", (int)sram_write_to_io_address_buffer},
+                 {"size", (int)(to_io_data_buffer.size())},
+                 {"data", formatRawDataToWords(to_io_data_buffer)}});
 }
 
 std::string Iosram_both::dumpBackendContent() {
@@ -249,143 +263,110 @@ std::string Iosram_both::dumpBackendContent() {
 }
 
 void Iosram_both::writeToSRAM() {
-  std::string event_name =
-      "dsu_write_to_sram_" + std::to_string(current_event_number);
-  // Writing buffer data to the backend
-  agus[DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM].addEvent(
-      event_name,
-      [this, event_name] {
-        // Check if the IO responded
-        IOReadResponse *ioReadResponse =
-            dynamic_cast<IOReadResponse *>(io_input_link->recv());
-        if (ioReadResponse) {
-          out.output("Received read response from IO (addr=%d, size=%dbits, "
-                     "data=%s)\n",
-                     ioReadResponse->address, ioReadResponse->data.size() * 8,
-                     formatRawDataToWords(ioReadResponse->data).c_str());
-          from_io_data_buffer = ioReadResponse->data;
-          if (from_io_data_buffer.size() == 0) {
-            out.fatal(CALL_INFO, -1, "No data from IO\n");
-          }
-        } else {
-          out.fatal(CALL_INFO, -1, "No response from IO\n");
-        }
+  // Check if the IO responded
+  IOReadResponse *ioReadResponse =
+      dynamic_cast<IOReadResponse *>(io_input_link->recv());
+  if (ioReadResponse) {
+    out.output("Received read response from IO (addr=%d, size=%dbits, "
+               "data=%s)\n",
+               ioReadResponse->address, ioReadResponse->data.size() * 8,
+               formatRawDataToWords(ioReadResponse->data).c_str());
+    from_io_data_buffer = ioReadResponse->data;
+    if (from_io_data_buffer.size() == 0) {
+      out.fatal(CALL_INFO, -1, "No data from IO\n");
+    }
+  } else {
+    out.fatal(CALL_INFO, -1, "No response from IO\n");
+  }
 
-        // Calculate the SRAM address
-        io_write_to_sram_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM));
+  // Calculate the SRAM address
+  io_write_to_sram_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM));
 
-        // Write data to the backend (SRAM)
-        backend->set(io_write_to_sram_address_buffer,
-                     from_io_data_buffer.size(), from_io_data_buffer);
-        out.output("Writing to SRAM (addr=%d, size=%dbits, data=%s)\n",
-                   io_write_to_sram_address_buffer,
-                   from_io_data_buffer.size() * 8,
-                   formatRawDataToWords(from_io_data_buffer).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)io_write_to_sram_address_buffer},
-                       {"size", (int)(from_io_data_buffer.size())},
-                       {"data", formatRawDataToWords(from_io_data_buffer)}});
+  // Write data to the backend (SRAM)
+  backend->set(io_write_to_sram_address_buffer, from_io_data_buffer.size(),
+               from_io_data_buffer);
+  out.output("Writing to SRAM (addr=%d, size=%dbits, data=%s)\n",
+             io_write_to_sram_address_buffer, from_io_data_buffer.size() * 8,
+             formatRawDataToWords(from_io_data_buffer).c_str());
+  logTraceEvent("io_write_to_sram", slot_id, true, 'X',
+                {{"address", (int)io_write_to_sram_address_buffer},
+                 {"size", (int)(from_io_data_buffer.size())},
+                 {"data", formatRawDataToWords(from_io_data_buffer)}});
 
-        // Clear the buffer
-        from_io_data_buffer.clear();
+  // Clear the buffer
+  from_io_data_buffer.clear();
 
-        // Log memory state
-        logTraceEvent("memory", slot_id, true, 'E', {});
-        logTraceEvent("memory", slot_id, true, 'B',
-                      {{"memory", dumpBackendContent()}});
-      },
-      8);
+  // Log memory state
+  logTraceEvent("memory", slot_id, true, 'E', {});
+  logTraceEvent("memory", slot_id, true, 'B',
+                {{"memory", dumpBackendContent()}});
 }
 
 void Iosram_both::readFromSRAM() {
-  std::string event_name =
-      "dsu_read_from_sram_" + std::to_string(current_event_number);
-  // Reading data from the backend to the buffer
-  agus[DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM].addEvent(
-      event_name,
-      [this, event_name] {
-        io_read_from_sram_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM));
+  io_read_from_sram_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM));
 
-        to_io_data_buffer.clear();
-        backend->get(io_read_from_sram_address_buffer, io_data_width / 8,
-                     to_io_data_buffer);
+  to_io_data_buffer.clear();
+  backend->get(io_read_from_sram_address_buffer, io_data_width / 8,
+               to_io_data_buffer);
 
-        out.output("Reading from SRAM (addr=%d, size=%dbits, data=%s)\n",
-                   io_read_from_sram_address_buffer, io_data_width,
-                   formatRawDataToWords(to_io_data_buffer).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)io_read_from_sram_address_buffer},
-                       {"size", (int)(io_data_width / 8)},
-                       {"data", formatRawDataToWords(to_io_data_buffer)}});
-      },
-      2);
+  out.output("Reading from SRAM (addr=%d, size=%dbits, data=%s)\n",
+             io_read_from_sram_address_buffer, io_data_width,
+             formatRawDataToWords(to_io_data_buffer).c_str());
+  logTraceEvent("io_read_from_sram", slot_id, true, 'X',
+                {{"address", (int)io_read_from_sram_address_buffer},
+                 {"size", (int)(io_data_width / 8)},
+                 {"data", formatRawDataToWords(to_io_data_buffer)}});
 }
 
 void Iosram_both::readBulk() {
-  std::string event_name =
-      "dsu_read_bulk_" + std::to_string(current_event_number);
-  agus[DSU_RELATIVE_PORT::DSU_PORT_READ_BULK].addEvent(
-      event_name,
-      [this, event_name] {
-        read_bulk_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_READ_BULK].getAddressForCycle(
-                getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK));
-        out.output("Initiating bulk read (addr=%d, size=%dbits)\n",
-                   read_bulk_address_buffer, io_data_width);
-        DataEvent *dataEvent = new DataEvent(DataEvent::PortType::WriteWide);
-        vector<uint8_t> data;
-        backend->get(read_bulk_address_buffer, io_data_width / 8, data);
-        out.output("Reading bulk data (addr=%d, size=%dbits, data=%s)\n",
-                   read_bulk_address_buffer, io_data_width,
-                   formatRawDataToWords(data).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)read_bulk_address_buffer},
-                       {"size", (int)(io_data_width / 8)},
-                       {"data", formatRawDataToWords(data)}});
-        dataEvent->size = io_data_width;
-        dataEvent->payload = data;
-        data_links[1]->send(dataEvent);
-      },
-      1);
+  read_bulk_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_READ_BULK].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK));
+  out.output("Initiating bulk read (addr=%d, size=%dbits)\n",
+             read_bulk_address_buffer, io_data_width);
+  DataEvent *dataEvent = new DataEvent(DataEvent::PortType::WriteWide);
+  vector<uint8_t> data;
+  backend->get(read_bulk_address_buffer, io_data_width / 8, data);
+  out.output("Reading bulk data (addr=%d, size=%dbits, data=%s)\n",
+             read_bulk_address_buffer, io_data_width,
+             formatRawDataToWords(data).c_str());
+  logTraceEvent("iosram_read_bulk", slot_id, true, 'X',
+                {{"address", (int)read_bulk_address_buffer},
+                 {"size", (int)(io_data_width / 8)},
+                 {"data", formatRawDataToWords(data)}});
+  dataEvent->size = io_data_width;
+  dataEvent->payload = data;
+  data_links[1]->send(dataEvent);
 }
 
 void Iosram_both::writeBulk() {
-  std::string event_name =
-      "dsu_write_bulk_" + std::to_string(current_event_number);
-  agus[DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK].addEvent(
-      event_name,
-      [this, event_name] {
-        write_bulk_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK].getAddressForCycle(
-                getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK));
+  write_bulk_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK));
 
-        // Check if some data was received
-        DataEvent *dataEvent = dynamic_cast<DataEvent *>(data_links[1]->recv());
-        if (dataEvent == nullptr)
-          out.fatal(CALL_INFO, -1, "No data received\n");
+  // Check if some data was received
+  DataEvent *dataEvent = dynamic_cast<DataEvent *>(data_links[1]->recv());
+  if (dataEvent == nullptr)
+    out.fatal(CALL_INFO, -1, "No data received\n");
 
-        // Write data to the backend
-        backend->set(write_bulk_address_buffer, dataEvent->size / 8,
-                     dataEvent->payload);
+  // Write data to the backend
+  backend->set(write_bulk_address_buffer, dataEvent->size / 8,
+               dataEvent->payload);
 
-        out.output("Writing bulk data (addr=%d, size=%dbits, data=%s)\n",
-                   write_bulk_address_buffer, dataEvent->size,
-                   formatRawDataToWords(dataEvent->payload).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)write_bulk_address_buffer},
-                       {"size", (int)(dataEvent->size / 8)},
-                       {"data", formatRawDataToWords(dataEvent->payload)}});
+  out.output("Writing bulk data (addr=%d, size=%dbits, data=%s)\n",
+             write_bulk_address_buffer, dataEvent->size,
+             formatRawDataToWords(dataEvent->payload).c_str());
+  logTraceEvent("iosram_write_bulk", slot_id, true, 'X',
+                {{"address", (int)write_bulk_address_buffer},
+                 {"size", (int)(dataEvent->size / 8)},
+                 {"data", formatRawDataToWords(dataEvent->payload)}});
 
-        // Log memory state
-        logTraceEvent("memory", slot_id, true, 'E', {});
-        logTraceEvent("memory", slot_id, true, 'B',
-                      {{"memory", dumpBackendContent()}});
-      },
-      9);
+  // Log memory state
+  logTraceEvent("memory", slot_id, true, 'E', {});
+  logTraceEvent("memory", slot_id, true, 'B',
+                {{"memory", dumpBackendContent()}});
 }

--- a/lib/resources/iosram_both/sst/iosram_both.cpp
+++ b/lib/resources/iosram_both/sst/iosram_both.cpp
@@ -11,7 +11,7 @@ Iosram_both::Iosram_both(SST::ComponentId_t id, SST::Params &params)
     : DRRAResource(id, params) {
   instructionHandlers = IOSRAM_BOTH_PKG::createInstructionHandlers(this);
   access_time = params.find<std::string>("access_time", "0ns");
-  iosram_depth = 1u << params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
+  iosram_depth = 1ULL << params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
   read_only = params.find<bool>("read_only", false);
 
   // Backing store
@@ -75,10 +75,10 @@ void Iosram_both::handleActivation(uint32_t slot_id, uint32_t ports) {
 }
 
 void Iosram_both::handleDSU(const IOSRAM_BOTH_PKG::DSUInstruction &instr) {
-  out.output("dsu (slot=%d, port=%d, option=%d, init_addr_sd=%d, init_addr=%d, "
-             "port=%d)\n",
-             instr.slot, instr.port, instr.option, instr.init_addr_sd,
-             instr.init_addr);
+  out.output(
+      "dsu (slot=%d, port=%d, option=%d, init_addr_sd=%d, init_addr=%d)\n",
+      instr.slot, instr.port, instr.option, instr.init_addr_sd,
+      instr.init_addr);
 
   // Set initial address
   uint32_t port_num = getRelativePortNum(instr.slot, instr.port);

--- a/lib/resources/iosram_both/sst/iosram_both.cpp
+++ b/lib/resources/iosram_both/sst/iosram_both.cpp
@@ -91,7 +91,7 @@ void Iosram_both::handleDSU(const IOSRAM_BOTH_PKG::DSUInstruction &instr) {
   case DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO:
     event_name =
         "dsu_sram_read_from_io_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO);
@@ -101,7 +101,7 @@ void Iosram_both::handleDSU(const IOSRAM_BOTH_PKG::DSUInstruction &instr) {
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO:
     event_name = "dsu_sram_write_to_io_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO);
@@ -111,7 +111,7 @@ void Iosram_both::handleDSU(const IOSRAM_BOTH_PKG::DSUInstruction &instr) {
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM:
     event_name = "dsu_io_write_to_sram_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM);
@@ -122,7 +122,7 @@ void Iosram_both::handleDSU(const IOSRAM_BOTH_PKG::DSUInstruction &instr) {
   case DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM:
     event_name =
         "dsu_io_read_from_sram_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM);
@@ -132,7 +132,7 @@ void Iosram_both::handleDSU(const IOSRAM_BOTH_PKG::DSUInstruction &instr) {
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK:
     event_name = "dsu_write_bulk_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK);
@@ -142,7 +142,7 @@ void Iosram_both::handleDSU(const IOSRAM_BOTH_PKG::DSUInstruction &instr) {
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_READ_BULK:
     event_name = "dsu_read_bulk_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK);

--- a/lib/resources/iosram_both/sst/iosram_both.cpp
+++ b/lib/resources/iosram_both/sst/iosram_both.cpp
@@ -11,7 +11,7 @@ Iosram_both::Iosram_both(SST::ComponentId_t id, SST::Params &params)
     : DRRAResource(id, params) {
   instructionHandlers = IOSRAM_BOTH_PKG::createInstructionHandlers(this);
   access_time = params.find<std::string>("access_time", "0ns");
-  iosram_depth = 2 ^ params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
+  iosram_depth = 1u << params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
   read_only = params.find<bool>("read_only", false);
 
   // Backing store

--- a/lib/resources/iosram_both/sst/iosram_both.h
+++ b/lib/resources/iosram_both/sst/iosram_both.h
@@ -122,15 +122,21 @@ private:
   std::unordered_map<uint32_t, uint32_t> portsToActivate;
 
   void updatePortAGUs(uint32_t port) {
-    port_agus[port] = port_agus_init[port] +
-                      agus[port].getAddressForCycle(getPortActiveCycle(port));
+    int64_t address_offset =
+        agus[port].getAddressForCycle(getPortActiveCycle(port));
+    if (address_offset < 0) {
+      out.fatal(CALL_INFO, -1,
+                "AGU for port %u returned negative address %d for cycle %d\n",
+                port, address_offset, getPortActiveCycle(port));
+    }
+    port_agus[port] = port_agus_init[port] + address_offset;
     uint64_t max_addr = iosram_depth;
-    if (port == DSU_PORT_SRAM_READ_FROM_IO || port == DSU_PORT_SRAM_WRITE_TO_IO) {
+    if (port == DSU_PORT_SRAM_READ_FROM_IO ||
+        port == DSU_PORT_SRAM_WRITE_TO_IO) {
       max_addr = iosram_depth * (io_data_width / word_bitwidth);
     }
     if (port_agus[port] >= max_addr) {
-      out.fatal(CALL_INFO, -1,
-                "Invalid AGU address %u for port %u (max %lu)\n",
+      out.fatal(CALL_INFO, -1, "Invalid AGU address %u for port %u (max %lu)\n",
                 port_agus[port], port, max_addr);
     }
   }

--- a/lib/resources/iosram_both/sst/iosram_both.h
+++ b/lib/resources/iosram_both/sst/iosram_both.h
@@ -124,9 +124,14 @@ private:
   void updatePortAGUs(uint32_t port) {
     port_agus[port] = port_agus_init[port] +
                       agus[port].getAddressForCycle(getPortActiveCycle(port));
-    if (port_agus[port] >= iosram_depth) {
+    uint64_t max_addr = iosram_depth;
+    if (port == DSU_PORT_SRAM_READ_FROM_IO || port == DSU_PORT_SRAM_WRITE_TO_IO) {
+      max_addr = iosram_depth * (io_data_width / word_bitwidth);
+    }
+    if (port_agus[port] >= max_addr) {
       out.fatal(CALL_INFO, -1,
-                "Invalid AGU address (greater than IOSRAM size)\n");
+                "Invalid AGU address %u for port %u (max %lu)\n",
+                port_agus[port], port, max_addr);
     }
   }
 };

--- a/lib/resources/iosram_both/sst/iosram_both.h
+++ b/lib/resources/iosram_both/sst/iosram_both.h
@@ -59,8 +59,6 @@ public:
   bool clockTick(SST::Cycle_t currentCycle) override;
   void handleActivation(uint32_t slot_id, uint32_t ports) override;
 
-  std::unordered_map<uint32_t, uint32_t> portsToActivate;
-
   // Instruction format
   using DRRAResource::format;
   void handleDSU(const IOSRAM_BOTH_PKG::DSUInstruction &instr);
@@ -116,9 +114,21 @@ private:
   void writeBulk();
   void readBulk();
 
-  int32_t agu_initial_addr = -1;
   uint32_t current_event_number = 0;
   std::map<uint32_t, size_t> current_option_config;
+  std::map<uint32_t, uint32_t> port_agus_init;
+  std::map<uint32_t, uint32_t> port_agus;
+
+  std::unordered_map<uint32_t, uint32_t> portsToActivate;
+
+  void updatePortAGUs(uint32_t port) {
+    port_agus[port] = port_agus_init[port] +
+                      agus[port].getAddressForCycle(getPortActiveCycle(port));
+    if (port_agus[port] >= iosram_depth) {
+      out.fatal(CALL_INFO, -1,
+                "Invalid AGU address (greater than IOSRAM size)\n");
+    }
+  }
 };
 
 #endif // _IOSRAM_BOTH_H

--- a/lib/resources/iosram_btm/compile_util/src/main.rs
+++ b/lib/resources/iosram_btm/compile_util/src/main.rs
@@ -44,8 +44,8 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_rep = 0;
-    let mut current_trans = 0;
+    let mut current_level = [0, 0];
+    let mut current_trans = [0, 0];
     let mut t: HashMap<i64, String> = HashMap::new();
     let mut r: HashMap<i64, (String, String)> = HashMap::new();
     let mut expr = "e0".to_string();
@@ -54,21 +54,24 @@ fn get_timing_model(op: Op) -> String {
         let instr_segments = instr.params;
         match instr.kind.as_str() {
             "dsu" => {
-                current_rep = 0;
-                current_trans = 0;
+                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
+                current_level[port] = 0;
+                current_trans[port] = 0;
             }
             "rep" => {
+                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let iter = instr_segments.get_value("iter");
                 let delay = instr_segments.get_value("delay");
-                r.insert(current_rep, (iter.to_string(), delay.to_string()));
-                current_rep += 1;
+                r.insert(current_level[port], (iter.to_string(), delay.to_string()));
+                current_level[port] += 1;
             }
             "repx" => {}
-            "fsm" => {
+            "trans" => {
+                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let delay = instr_segments.get_value("delay");
-                t.insert(current_trans, delay);
-                current_rep = 0;
-                current_trans += 1;
+                t.insert(current_trans[port], delay);
+                current_level[port] = 0;
+                current_trans[port] += 1;
             }
             _ => {
                 panic!("Unknown instruction kind: {}", instr.kind);

--- a/lib/resources/iosram_btm/compile_util/src/main.rs
+++ b/lib/resources/iosram_btm/compile_util/src/main.rs
@@ -44,8 +44,8 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_level = [0, 0];
-    let mut current_trans = [0, 0];
+    let mut current_level = [0; 4];
+    let mut current_trans = [0; 4];
     let mut t: HashMap<i64, String> = HashMap::new();
     let mut r: HashMap<i64, (String, String)> = HashMap::new();
     let mut expr = "e0".to_string();

--- a/lib/resources/iosram_btm/compile_util/src/main.rs
+++ b/lib/resources/iosram_btm/compile_util/src/main.rs
@@ -33,7 +33,6 @@ use serde_json::json;
  *
  */
 use serde_json::Value;
-use std::collections::HashMap;
 use std::env;
 use std::ops::{Deref, DerefMut};
 
@@ -44,34 +43,31 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_level = [0; 4];
-    let mut current_trans = [0; 4];
-    let mut t: HashMap<i64, String> = HashMap::new();
-    let mut r: HashMap<i64, (String, String)> = HashMap::new();
-    let mut expr = "e0".to_string();
+    let mut segments: Vec<String> = Vec::new();
+    let mut event_counter = 0;
 
     for instr in op.body {
         let instr_segments = instr.params;
         match instr.kind.as_str() {
             "dsu" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
-                current_level[port] = 0;
-                current_trans[port] = 0;
+                segments.push(format!("e{}", event_counter));
+                event_counter += 1;
             }
             "rep" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let iter = instr_segments.get_value("iter");
                 let delay = instr_segments.get_value("delay");
-                r.insert(current_level[port], (iter.to_string(), delay.to_string()));
-                current_level[port] += 1;
+                if let Some(last) = segments.last_mut() {
+                    *last = format!("R<{},{}>({})", iter, delay, last);
+                }
             }
             "repx" => {}
             "trans" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let delay = instr_segments.get_value("delay");
-                t.insert(current_trans[port], delay);
-                current_level[port] = 0;
-                current_trans[port] += 1;
+                if segments.len() >= 2 {
+                    let right = segments.pop().unwrap();
+                    let left = segments.pop().unwrap();
+                    segments.push(format!("T<{}>({},{})", delay, left, right));
+                }
             }
             _ => {
                 panic!("Unknown instruction kind: {}", instr.kind);
@@ -79,31 +75,7 @@ fn get_timing_model(op: Op) -> String {
         }
     }
 
-    let mut event_counter = 1;
-    let mut t_keys: Vec<_> = t.keys().cloned().collect();
-    t_keys.sort();
-    for i in t_keys {
-        if let Some(delay) = t.get(&i) {
-            if delay != "0" {
-                expr = format!("T<{}>({}, e{})", delay, expr, event_counter);
-                event_counter += 1;
-            } else {
-                break;
-            }
-        }
-    }
-
-    let mut r_keys: Vec<_> = r.keys().cloned().collect();
-    r_keys.sort();
-    for i in r_keys {
-        if let Some(values) = r.get(&i) {
-            expr = format!("R<{},{}>({})", values.0, values.1, expr);
-        } else {
-            break;
-        }
-    }
-
-    expr
+    segments.pop().unwrap_or_else(|| "e0".to_string())
 }
 
 fn reshape_instr(op: Op) -> Op {
@@ -388,5 +360,63 @@ fn main() {
             std::fs::write(output_file, serde_json::to_string(&reshaped_json).unwrap()).unwrap();
         }
         _ => panic!("Unknown subcommand: {}", subcommand),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_instr(kind: &str, params: Vec<(&str, &str)>) -> Instr {
+        Instr {
+            kind: kind.to_string(),
+            id: "".to_string(),
+            params: InstrSegments::new(
+                params
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
+        }
+    }
+
+    fn make_op(body: Vec<Instr>) -> Op {
+        Op {
+            kind: "rop".to_string(),
+            id: "test".to_string(),
+            row: 0,
+            col: 0,
+            slot: 0,
+            port: 0,
+            body,
+        }
+    }
+
+    #[test]
+    fn test_transit_with_two_repeats() {
+        let op = make_op(vec![
+            make_instr("dsu", vec![("option", "0"), ("init_addr", "0")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "0"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("dsu", vec![("option", "1"), ("init_addr", "18")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "1"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("trans", vec![("delay", "0")]),
+        ]);
+        assert_eq!(get_timing_model(op), "T<0>(R<4,0>(e0),R<4,0>(e1))");
     }
 }

--- a/lib/resources/iosram_btm/sst/iosram_btm.cpp
+++ b/lib/resources/iosram_btm/sst/iosram_btm.cpp
@@ -75,33 +75,82 @@ void Iosram_btm::handleActivation(uint32_t slot_id, uint32_t ports) {
 }
 
 void Iosram_btm::handleDSU(const IOSRAM_BTM_PKG::DSUInstruction &instr) {
-  out.output("dsu (slot=%d, init_addr_sd=%d, init_addr=%d, port=%d)\n",
-             instr.slot, instr.init_addr_sd, instr.init_addr, instr.port);
+  out.output("dsu (slot=%d, port=%d, option=%d, init_addr_sd=%d, init_addr=%d, "
+             "port=%d)\n",
+             instr.slot, instr.port, instr.option, instr.init_addr_sd,
+             instr.init_addr);
 
-  // Add the event handler
+  // Set initial address
   uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
   agus[port_num].setInitialAddress(instr.init_addr);
+  out.output("Set initial address for port %d to %d\n", port_num,
+             instr.init_addr);
 
+  std::string event_name;
   switch (port_num) {
   case DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO:
     out.fatal(CALL_INFO, -1,
               "Invalid DSU mode IOSRAM Btm should not read from IO\n");
-    readFromIO();
+    event_name =
+        "dsu_sram_read_from_io_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO);
+          readFromIO();
+        },
+        1);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO:
-    writeToIO();
+    event_name = "dsu_sram_write_to_io_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO);
+          writeToIO();
+        },
+        9);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM:
-    writeToSRAM();
+    event_name = "dsu_io_write_to_sram_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM);
+          writeToSRAM();
+        },
+        8);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM:
-    readFromSRAM();
+    event_name =
+        "dsu_io_read_from_sram_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM);
+          readFromSRAM();
+        },
+        2);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK:
-    writeBulk();
+    event_name = "dsu_write_bulk_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK);
+          writeBulk();
+        },
+        9);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_READ_BULK:
-    readBulk();
+    event_name = "dsu_read_bulk_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK);
+          readBulk();
+        },
+        1);
     break;
 
   default:
@@ -116,27 +165,7 @@ void Iosram_btm::handleREP(const IOSRAM_BTM_PKG::REPInstruction &instr) {
   out.output("rep (slot=%d, port=%d, iter=%d, step=%d, delay=%d)\n", instr.slot,
              instr.port, instr.iter, instr.step, instr.delay);
 
-  uint32_t port_num = 0;
-  auto it = std::find(slot_ids.begin(), slot_ids.end(), instr.slot);
-  if (it != slot_ids.end()) {
-    port_num = std::distance(slot_ids.begin(), it);
-  } else {
-    out.fatal(CALL_INFO, -1, "Slot ID not found\n");
-  }
-  port_num = port_num * 4 + instr.port;
-
-  // // For now, we only support increasing repetition levels (and no skipping)
-  // if (instr.level != port_last_rep_level[port_num] + 1) {
-  //   out.output("port_num = %d\n", port_num);
-  //   out.fatal(
-  //       CALL_INFO, -1,
-  //       "Invalid repetition level (last=%d, curr=%d), instruction: (slot: "
-  //       "%d, port: %d, level: %d, iter: %d, step: %d, delay: %d)\n",
-  //       port_last_rep_level[port_num], instr.level, instr.slot, instr.port,
-  //       instr.level, instr.iter, instr.step, instr.delay);
-  // } else {
-  //   port_last_rep_level[port_num] = instr.level;
-  // }
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
 
   // add repetition to the timing model
   try {
@@ -152,15 +181,7 @@ void Iosram_btm::handleREPX(const IOSRAM_BTM_PKG::REPXInstruction &instr) {
   out.output("repx (slot=%d, port=%d, iter=%d, step=%d, delay=%d)\n",
              instr.slot, instr.port, instr.iter, instr.step, instr.delay);
 
-  uint32_t port_num = 0;
-  auto it = std::find(slot_ids.begin(), slot_ids.end(), instr.slot);
-  if (it != slot_ids.end()) {
-    port_num = std::distance(slot_ids.begin(), it);
-  } else {
-    out.fatal(CALL_INFO, -1, "Slot ID not found\n");
-  }
-  port_num = port_num * 4 + instr.port;
-
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
   auto repetition_op = agus[port_num].getLastRepetitionOperator();
   uint32_t iter = instr.iter
                       << IOSRAM_BTM_PKG::IOSRAM_BTM_INSTR_REPX_ITER_BITWIDTH |
@@ -180,61 +201,56 @@ void Iosram_btm::handleREPX(const IOSRAM_BTM_PKG::REPXInstruction &instr) {
   }
 }
 
+void Iosram_btm::handleTRANS(const IOSRAM_BTM_PKG::TRANSInstruction &instr) {
+  out.output("trans (slot=%d, port=%d, delay=%d)\n", instr.slot, instr.port,
+             instr.delay);
+
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
+
+  try {
+    agus[port_num].addTransition(instr.delay);
+    current_event_number++;
+  } catch (const std::exception &e) {
+    out.fatal(CALL_INFO, -1, "Failed to add transition: %s\n", e.what());
+  }
+}
+
 void Iosram_btm::readFromIO() {
-  std::string event_name =
-      "dsu_read_from_io_" + std::to_string(current_event_number);
-  // Reading data from the IO to the buffer
-  agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO].addEvent(
-      event_name,
-      [this, event_name] {
-        sram_read_from_io_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO));
+  sram_read_from_io_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO));
 
-        IOReadRequest *readReq = new IOReadRequest();
-        readReq->address = sram_read_from_io_address_buffer;
-        readReq->size = io_data_width / 8;
-        readReq->column_id = cell_coordinates[1];
+  IOReadRequest *readReq = new IOReadRequest();
+  readReq->address = sram_read_from_io_address_buffer;
+  readReq->size = io_data_width / 8;
+  readReq->column_id = cell_coordinates[1];
 
-        out.output("Sending read request to IO (addr=%d, size=%dbits)\n",
-                   sram_read_from_io_address_buffer, io_data_width);
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)sram_read_from_io_address_buffer},
-                       {"size", (int)(io_data_width / 8)}});
+  out.output("Sending read request to IO (addr=%d, size=%dbits)\n",
+             sram_read_from_io_address_buffer, io_data_width);
+  logTraceEvent("iosram_read_from_io", slot_id, true, 'X',
+                {{"address", (int)sram_read_from_io_address_buffer},
+                 {"size", (int)(io_data_width / 8)}});
 
-        io_input_link->send(readReq);
-      },
-      1);
+  io_input_link->send(readReq);
 }
 
 void Iosram_btm::writeToIO() {
-  std::string event_name =
-      "dsu_write_to_io_" + std::to_string(current_event_number);
-  // Writing buffer data to the IO
-  agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO].addEvent(
-      event_name,
-      [this, event_name] {
-        sram_write_to_io_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO));
+  sram_write_to_io_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO));
 
-        IOWriteRequest *writeReq = new IOWriteRequest();
-        writeReq->address = sram_write_to_io_address_buffer;
-        writeReq->data = to_io_data_buffer;
-        io_output_link->send(writeReq);
+  IOWriteRequest *writeReq = new IOWriteRequest();
+  writeReq->address = sram_write_to_io_address_buffer;
+  writeReq->data = to_io_data_buffer;
+  io_output_link->send(writeReq);
 
-        out.output(
-            "Sending write request to IO (addr=%d, size=%dbits, data=%s)\n",
-            writeReq->address, writeReq->data.size() * 8,
-            formatRawDataToWords(writeReq->data).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)sram_write_to_io_address_buffer},
-                       {"size", (int)(to_io_data_buffer.size())},
-                       {"data", formatRawDataToWords(to_io_data_buffer)}});
-      },
-      9);
+  out.output("Sending write request to IO (addr=%d, size=%dbits, data=%s)\n",
+             writeReq->address, writeReq->data.size() * 8,
+             formatRawDataToWords(writeReq->data).c_str());
+  logTraceEvent("iosram_write_to_io", slot_id, true, 'X',
+                {{"address", (int)sram_write_to_io_address_buffer},
+                 {"size", (int)(to_io_data_buffer.size())},
+                 {"data", formatRawDataToWords(to_io_data_buffer)}});
 }
 
 std::string Iosram_btm::dumpBackendContent() {
@@ -249,142 +265,110 @@ std::string Iosram_btm::dumpBackendContent() {
 }
 
 void Iosram_btm::writeToSRAM() {
-  std::string event_name =
-      "dsu_write_to_sram_" + std::to_string(current_event_number);
-  // Writing buffer data to the backend
-  agus[DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM].addEvent(
-      event_name,
-      [this, event_name] {
-        // Check if the IO responded
-        IOReadResponse *ioReadResponse =
-            dynamic_cast<IOReadResponse *>(io_input_link->recv());
-        if (ioReadResponse) {
-          out.output("Received read response from IO (addr=%d, size=%dbits, "
-                     "data=%s)\n",
-                     ioReadResponse->address, ioReadResponse->data.size() * 8,
-                     formatRawDataToWords(ioReadResponse->data).c_str());
-          from_io_data_buffer = ioReadResponse->data;
-          if (from_io_data_buffer.size() == 0) {
-            out.fatal(CALL_INFO, -1, "No data from IO\n");
-          }
-        } else {
-          out.fatal(CALL_INFO, -1, "No response from IO\n");
-        }
+  // Check if the IO responded
+  IOReadResponse *ioReadResponse =
+      dynamic_cast<IOReadResponse *>(io_input_link->recv());
+  if (ioReadResponse) {
+    out.output("Received read response from IO (addr=%d, size=%dbits, "
+               "data=%s)\n",
+               ioReadResponse->address, ioReadResponse->data.size() * 8,
+               formatRawDataToWords(ioReadResponse->data).c_str());
+    from_io_data_buffer = ioReadResponse->data;
+    if (from_io_data_buffer.size() == 0) {
+      out.fatal(CALL_INFO, -1, "No data from IO\n");
+    }
+  } else {
+    out.fatal(CALL_INFO, -1, "No response from IO\n");
+  }
 
-        // Calculate the SRAM address
-        io_write_to_sram_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM));
+  // Calculate the SRAM address
+  io_write_to_sram_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM));
 
-        // Write data to the backend (SRAM)
-        backend->set(io_write_to_sram_address_buffer,
-                     from_io_data_buffer.size(), from_io_data_buffer);
-        out.output("Writing to SRAM (addr=%d, size=%dbits, data=%s)\n",
-                   io_write_to_sram_address_buffer,
-                   from_io_data_buffer.size() * 8,
-                   formatRawDataToWords(from_io_data_buffer).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)io_write_to_sram_address_buffer},
-                       {"size", (int)(from_io_data_buffer.size())},
-                       {"data", formatRawDataToWords(from_io_data_buffer)}});
+  // Write data to the backend (SRAM)
+  backend->set(io_write_to_sram_address_buffer, from_io_data_buffer.size(),
+               from_io_data_buffer);
+  out.output("Writing to SRAM (addr=%d, size=%dbits, data=%s)\n",
+             io_write_to_sram_address_buffer, from_io_data_buffer.size() * 8,
+             formatRawDataToWords(from_io_data_buffer).c_str());
+  logTraceEvent("io_write_to_sram", slot_id, true, 'X',
+                {{"address", (int)io_write_to_sram_address_buffer},
+                 {"size", (int)(from_io_data_buffer.size())},
+                 {"data", formatRawDataToWords(from_io_data_buffer)}});
 
-        // Clear the buffer
-        from_io_data_buffer.clear();
+  // Clear the buffer
+  from_io_data_buffer.clear();
 
-        // Log memory state
-        logTraceEvent("memory", slot_id, true, 'E', {});
-        logTraceEvent("memory", slot_id, true, 'B',
-                      {{"memory", dumpBackendContent()}});
-      },
-      8);
+  // Log memory state
+  logTraceEvent("memory", slot_id, true, 'E', {});
+  logTraceEvent("memory", slot_id, true, 'B',
+                {{"memory", dumpBackendContent()}});
 }
 
 void Iosram_btm::readFromSRAM() {
-  std::string event_name =
-      "dsu_read_from_sram_" + std::to_string(current_event_number);
-  // Reading data from the backend to the buffer
-  agus[DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM].addEvent(
-      event_name,
-      [this, event_name] {
-        io_read_from_sram_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM));
+  io_read_from_sram_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM));
 
-        to_io_data_buffer.clear();
-        backend->get(io_read_from_sram_address_buffer, io_data_width / 8,
-                     to_io_data_buffer);
+  to_io_data_buffer.clear();
+  backend->get(io_read_from_sram_address_buffer, io_data_width / 8,
+               to_io_data_buffer);
 
-        out.output("Reading from SRAM (addr=%d, size=%dbits, data=%s)\n",
-                   io_read_from_sram_address_buffer, io_data_width,
-                   formatRawDataToWords(to_io_data_buffer).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)io_read_from_sram_address_buffer},
-                       {"size", (int)(io_data_width / 8)},
-                       {"data", formatRawDataToWords(to_io_data_buffer)}});
-      },
-      2);
+  out.output("Reading from SRAM (addr=%d, size=%dbits, data=%s)\n",
+             io_read_from_sram_address_buffer, io_data_width,
+             formatRawDataToWords(to_io_data_buffer).c_str());
+  logTraceEvent("io_read_from_sram", slot_id, true, 'X',
+                {{"address", (int)io_read_from_sram_address_buffer},
+                 {"size", (int)(io_data_width / 8)},
+                 {"data", formatRawDataToWords(to_io_data_buffer)}});
 }
 
 void Iosram_btm::readBulk() {
-  std::string event_name =
-      "dsu_read_bulk_" + std::to_string(current_event_number);
-  agus[DSU_RELATIVE_PORT::DSU_PORT_READ_BULK].addEvent(
-      event_name,
-      [this, event_name] {
-        read_bulk_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_READ_BULK].getAddressForCycle(
-                getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK));
-
-        DataEvent *dataEvent = new DataEvent(DataEvent::PortType::WriteWide);
-        vector<uint8_t> data;
-        backend->get(read_bulk_address_buffer, io_data_width / 8, data);
-        out.output("Reading bulk data (addr=%d, size=%dbits, data=%s)\n",
-                   read_bulk_address_buffer, io_data_width,
-                   formatRawDataToWords(data).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)read_bulk_address_buffer},
-                       {"size", (int)(io_data_width / 8)},
-                       {"data", formatRawDataToWords(data)}});
-        dataEvent->size = io_data_width;
-        dataEvent->payload = data;
-        data_links[1]->send(dataEvent);
-      },
-      1);
+  read_bulk_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_READ_BULK].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK));
+  out.output("Initiating bulk read (addr=%d, size=%dbits)\n",
+             read_bulk_address_buffer, io_data_width);
+  DataEvent *dataEvent = new DataEvent(DataEvent::PortType::WriteWide);
+  vector<uint8_t> data;
+  backend->get(read_bulk_address_buffer, io_data_width / 8, data);
+  out.output("Reading bulk data (addr=%d, size=%dbits, data=%s)\n",
+             read_bulk_address_buffer, io_data_width,
+             formatRawDataToWords(data).c_str());
+  logTraceEvent("iosram_read_bulk", slot_id, true, 'X',
+                {{"address", (int)read_bulk_address_buffer},
+                 {"size", (int)(io_data_width / 8)},
+                 {"data", formatRawDataToWords(data)}});
+  dataEvent->size = io_data_width;
+  dataEvent->payload = data;
+  data_links[1]->send(dataEvent);
 }
 
 void Iosram_btm::writeBulk() {
-  std::string event_name =
-      "dsu_write_bulk_" + std::to_string(current_event_number);
-  agus[DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK].addEvent(
-      event_name,
-      [this, event_name] {
-        write_bulk_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK].getAddressForCycle(
-                getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK));
+  write_bulk_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK));
 
-        // Check if some data was received
-        DataEvent *dataEvent = dynamic_cast<DataEvent *>(data_links[1]->recv());
-        if (dataEvent == nullptr)
-          out.fatal(CALL_INFO, -1, "No data received\n");
+  // Check if some data was received
+  DataEvent *dataEvent = dynamic_cast<DataEvent *>(data_links[1]->recv());
+  if (dataEvent == nullptr)
+    out.fatal(CALL_INFO, -1, "No data received\n");
 
-        // Write data to the backend
-        backend->set(write_bulk_address_buffer, dataEvent->size / 8,
-                     dataEvent->payload);
+  // Write data to the backend
+  backend->set(write_bulk_address_buffer, dataEvent->size / 8,
+               dataEvent->payload);
 
-        out.output("Writing bulk data (addr=%d, size=%dbits, data=%s)\n",
-                   write_bulk_address_buffer, dataEvent->size,
-                   formatRawDataToWords(dataEvent->payload).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)write_bulk_address_buffer},
-                       {"size", (int)(dataEvent->size / 8)},
-                       {"data", formatRawDataToWords(dataEvent->payload)}});
+  out.output("Writing bulk data (addr=%d, size=%dbits, data=%s)\n",
+             write_bulk_address_buffer, dataEvent->size,
+             formatRawDataToWords(dataEvent->payload).c_str());
+  logTraceEvent("iosram_write_bulk", slot_id, true, 'X',
+                {{"address", (int)write_bulk_address_buffer},
+                 {"size", (int)(dataEvent->size / 8)},
+                 {"data", formatRawDataToWords(dataEvent->payload)}});
 
-        // Log memory state
-        logTraceEvent("memory", slot_id, true, 'E', {});
-        logTraceEvent("memory", slot_id, true, 'B',
-                      {{"memory", dumpBackendContent()}});
-      },
-      9);
+  // Log memory state
+  logTraceEvent("memory", slot_id, true, 'E', {});
+  logTraceEvent("memory", slot_id, true, 'B',
+                {{"memory", dumpBackendContent()}});
 }

--- a/lib/resources/iosram_btm/sst/iosram_btm.cpp
+++ b/lib/resources/iosram_btm/sst/iosram_btm.cpp
@@ -93,7 +93,7 @@ void Iosram_btm::handleDSU(const IOSRAM_BTM_PKG::DSUInstruction &instr) {
               "Invalid DSU mode IOSRAM Btm should not read from IO\n");
     event_name =
         "dsu_sram_read_from_io_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO);
@@ -103,7 +103,7 @@ void Iosram_btm::handleDSU(const IOSRAM_BTM_PKG::DSUInstruction &instr) {
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO:
     event_name = "dsu_sram_write_to_io_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO);
@@ -113,7 +113,7 @@ void Iosram_btm::handleDSU(const IOSRAM_BTM_PKG::DSUInstruction &instr) {
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM:
     event_name = "dsu_io_write_to_sram_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM);
@@ -124,7 +124,7 @@ void Iosram_btm::handleDSU(const IOSRAM_BTM_PKG::DSUInstruction &instr) {
   case DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM:
     event_name =
         "dsu_io_read_from_sram_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM);
@@ -134,7 +134,7 @@ void Iosram_btm::handleDSU(const IOSRAM_BTM_PKG::DSUInstruction &instr) {
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK:
     event_name = "dsu_write_bulk_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK);
@@ -144,7 +144,7 @@ void Iosram_btm::handleDSU(const IOSRAM_BTM_PKG::DSUInstruction &instr) {
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_READ_BULK:
     event_name = "dsu_read_bulk_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK);

--- a/lib/resources/iosram_btm/sst/iosram_btm.cpp
+++ b/lib/resources/iosram_btm/sst/iosram_btm.cpp
@@ -11,7 +11,7 @@ Iosram_btm::Iosram_btm(SST::ComponentId_t id, SST::Params &params)
     : DRRAResource(id, params) {
   instructionHandlers = IOSRAM_BTM_PKG::createInstructionHandlers(this);
   access_time = params.find<std::string>("access_time", "0ns");
-  iosram_depth = 1u << params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
+  iosram_depth = 1ULL << params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
   read_only = params.find<bool>("read_only", false);
 
   // Backing store
@@ -75,10 +75,10 @@ void Iosram_btm::handleActivation(uint32_t slot_id, uint32_t ports) {
 }
 
 void Iosram_btm::handleDSU(const IOSRAM_BTM_PKG::DSUInstruction &instr) {
-  out.output("dsu (slot=%d, port=%d, option=%d, init_addr_sd=%d, init_addr=%d, "
-             "port=%d)\n",
-             instr.slot, instr.port, instr.option, instr.init_addr_sd,
-             instr.init_addr);
+  out.output(
+      "dsu (slot=%d, port=%d, option=%d, init_addr_sd=%d, init_addr=%d)\n",
+      instr.slot, instr.port, instr.option, instr.init_addr_sd,
+      instr.init_addr);
 
   // Set initial address
   uint32_t port_num = getRelativePortNum(instr.slot, instr.port);

--- a/lib/resources/iosram_btm/sst/iosram_btm.cpp
+++ b/lib/resources/iosram_btm/sst/iosram_btm.cpp
@@ -11,7 +11,7 @@ Iosram_btm::Iosram_btm(SST::ComponentId_t id, SST::Params &params)
     : DRRAResource(id, params) {
   instructionHandlers = IOSRAM_BTM_PKG::createInstructionHandlers(this);
   access_time = params.find<std::string>("access_time", "0ns");
-  iosram_depth = 2 ^ params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
+  iosram_depth = 1u << params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
   read_only = params.find<bool>("read_only", false);
 
   // Backing store

--- a/lib/resources/iosram_btm/sst/iosram_btm.h
+++ b/lib/resources/iosram_btm/sst/iosram_btm.h
@@ -122,15 +122,21 @@ private:
   std::unordered_map<uint32_t, uint32_t> portsToActivate;
 
   void updatePortAGUs(uint32_t port) {
-    port_agus[port] = port_agus_init[port] +
-                      agus[port].getAddressForCycle(getPortActiveCycle(port));
+    int64_t address_offset =
+        agus[port].getAddressForCycle(getPortActiveCycle(port));
+    if (address_offset < 0) {
+      out.fatal(CALL_INFO, -1,
+                "AGU for port %u returned negative address %d for cycle %d\n",
+                port, address_offset, getPortActiveCycle(port));
+    }
+    port_agus[port] = port_agus_init[port] + address_offset;
     uint64_t max_addr = iosram_depth;
-    if (port == DSU_PORT_SRAM_READ_FROM_IO || port == DSU_PORT_SRAM_WRITE_TO_IO) {
+    if (port == DSU_PORT_SRAM_READ_FROM_IO ||
+        port == DSU_PORT_SRAM_WRITE_TO_IO) {
       max_addr = iosram_depth * (io_data_width / word_bitwidth);
     }
     if (port_agus[port] >= max_addr) {
-      out.fatal(CALL_INFO, -1,
-                "Invalid AGU address %u for port %u (max %lu)\n",
+      out.fatal(CALL_INFO, -1, "Invalid AGU address %u for port %u (max %lu)\n",
                 port_agus[port], port, max_addr);
     }
   }

--- a/lib/resources/iosram_btm/sst/iosram_btm.h
+++ b/lib/resources/iosram_btm/sst/iosram_btm.h
@@ -59,8 +59,6 @@ public:
   bool clockTick(SST::Cycle_t currentCycle) override;
   void handleActivation(uint32_t slot_id, uint32_t ports) override;
 
-  std::unordered_map<uint32_t, uint32_t> portsToActivate;
-
   // Instruction format
   using DRRAResource::format;
   void handleDSU(const IOSRAM_BTM_PKG::DSUInstruction &instr);
@@ -116,9 +114,21 @@ private:
   void writeBulk();
   void readBulk();
 
-  int32_t agu_initial_addr = -1;
   uint32_t current_event_number = 0;
   std::map<uint32_t, size_t> current_option_config;
+  std::map<uint32_t, uint32_t> port_agus_init;
+  std::map<uint32_t, uint32_t> port_agus;
+
+  std::unordered_map<uint32_t, uint32_t> portsToActivate;
+
+  void updatePortAGUs(uint32_t port) {
+    port_agus[port] = port_agus_init[port] +
+                      agus[port].getAddressForCycle(getPortActiveCycle(port));
+    if (port_agus[port] >= iosram_depth) {
+      out.fatal(CALL_INFO, -1,
+                "Invalid AGU address (greater than IOSRAM size)\n");
+    }
+  }
 };
 
 #endif // _IOSRAM_BTM_H

--- a/lib/resources/iosram_btm/sst/iosram_btm.h
+++ b/lib/resources/iosram_btm/sst/iosram_btm.h
@@ -124,9 +124,14 @@ private:
   void updatePortAGUs(uint32_t port) {
     port_agus[port] = port_agus_init[port] +
                       agus[port].getAddressForCycle(getPortActiveCycle(port));
-    if (port_agus[port] >= iosram_depth) {
+    uint64_t max_addr = iosram_depth;
+    if (port == DSU_PORT_SRAM_READ_FROM_IO || port == DSU_PORT_SRAM_WRITE_TO_IO) {
+      max_addr = iosram_depth * (io_data_width / word_bitwidth);
+    }
+    if (port_agus[port] >= max_addr) {
       out.fatal(CALL_INFO, -1,
-                "Invalid AGU address (greater than IOSRAM size)\n");
+                "Invalid AGU address %u for port %u (max %lu)\n",
+                port_agus[port], port, max_addr);
     }
   }
 };

--- a/lib/resources/iosram_top/compile_util/src/main.rs
+++ b/lib/resources/iosram_top/compile_util/src/main.rs
@@ -44,8 +44,8 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_rep = 0;
-    let mut current_trans = 0;
+    let mut current_level = [0, 0];
+    let mut current_trans = [0, 0];
     let mut t: HashMap<i64, String> = HashMap::new();
     let mut r: HashMap<i64, (String, String)> = HashMap::new();
     let mut expr = "e0".to_string();
@@ -54,21 +54,24 @@ fn get_timing_model(op: Op) -> String {
         let instr_segments = instr.params;
         match instr.kind.as_str() {
             "dsu" => {
-                current_rep = 0;
-                current_trans = 0;
+                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
+                current_level[port] = 0;
+                current_trans[port] = 0;
             }
             "rep" => {
+                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let iter = instr_segments.get_value("iter");
                 let delay = instr_segments.get_value("delay");
-                r.insert(current_rep, (iter.to_string(), delay.to_string()));
-                current_rep += 1;
+                r.insert(current_level[port], (iter.to_string(), delay.to_string()));
+                current_level[port] += 1;
             }
             "repx" => {}
-            "fsm" => {
+            "trans" => {
+                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let delay = instr_segments.get_value("delay");
-                t.insert(current_trans, delay);
-                current_rep = 0;
-                current_trans += 1;
+                t.insert(current_trans[port], delay);
+                current_level[port] = 0;
+                current_trans[port] += 1;
             }
             _ => {
                 panic!("Unknown instruction kind: {}", instr.kind);

--- a/lib/resources/iosram_top/compile_util/src/main.rs
+++ b/lib/resources/iosram_top/compile_util/src/main.rs
@@ -44,8 +44,8 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_level = [0, 0];
-    let mut current_trans = [0, 0];
+    let mut current_level = [0; 4];
+    let mut current_trans = [0; 4];
     let mut t: HashMap<i64, String> = HashMap::new();
     let mut r: HashMap<i64, (String, String)> = HashMap::new();
     let mut expr = "e0".to_string();

--- a/lib/resources/iosram_top/compile_util/src/main.rs
+++ b/lib/resources/iosram_top/compile_util/src/main.rs
@@ -33,7 +33,6 @@ use serde_json::json;
  *
  */
 use serde_json::Value;
-use std::collections::HashMap;
 use std::env;
 use std::ops::{Deref, DerefMut};
 
@@ -44,34 +43,31 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_level = [0; 4];
-    let mut current_trans = [0; 4];
-    let mut t: HashMap<i64, String> = HashMap::new();
-    let mut r: HashMap<i64, (String, String)> = HashMap::new();
-    let mut expr = "e0".to_string();
+    let mut segments: Vec<String> = Vec::new();
+    let mut event_counter = 0;
 
     for instr in op.body {
         let instr_segments = instr.params;
         match instr.kind.as_str() {
             "dsu" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
-                current_level[port] = 0;
-                current_trans[port] = 0;
+                segments.push(format!("e{}", event_counter));
+                event_counter += 1;
             }
             "rep" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let iter = instr_segments.get_value("iter");
                 let delay = instr_segments.get_value("delay");
-                r.insert(current_level[port], (iter.to_string(), delay.to_string()));
-                current_level[port] += 1;
+                if let Some(last) = segments.last_mut() {
+                    *last = format!("R<{},{}>({})", iter, delay, last);
+                }
             }
             "repx" => {}
             "trans" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let delay = instr_segments.get_value("delay");
-                t.insert(current_trans[port], delay);
-                current_level[port] = 0;
-                current_trans[port] += 1;
+                if segments.len() >= 2 {
+                    let right = segments.pop().unwrap();
+                    let left = segments.pop().unwrap();
+                    segments.push(format!("T<{}>({},{})", delay, left, right));
+                }
             }
             _ => {
                 panic!("Unknown instruction kind: {}", instr.kind);
@@ -79,31 +75,7 @@ fn get_timing_model(op: Op) -> String {
         }
     }
 
-    let mut event_counter = 1;
-    let mut t_keys: Vec<_> = t.keys().cloned().collect();
-    t_keys.sort();
-    for i in t_keys {
-        if let Some(delay) = t.get(&i) {
-            if delay != "0" {
-                expr = format!("T<{}>({}, e{})", delay, expr, event_counter);
-                event_counter += 1;
-            } else {
-                break;
-            }
-        }
-    }
-
-    let mut r_keys: Vec<_> = r.keys().cloned().collect();
-    r_keys.sort();
-    for i in r_keys {
-        if let Some(values) = r.get(&i) {
-            expr = format!("R<{},{}>({})", values.0, values.1, expr);
-        } else {
-            break;
-        }
-    }
-
-    expr
+    segments.pop().unwrap_or_else(|| "e0".to_string())
 }
 
 fn reshape_instr(op: Op) -> Op {
@@ -388,5 +360,63 @@ fn main() {
             std::fs::write(output_file, serde_json::to_string(&reshaped_json).unwrap()).unwrap();
         }
         _ => panic!("Unknown subcommand: {}", subcommand),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_instr(kind: &str, params: Vec<(&str, &str)>) -> Instr {
+        Instr {
+            kind: kind.to_string(),
+            id: "".to_string(),
+            params: InstrSegments::new(
+                params
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
+        }
+    }
+
+    fn make_op(body: Vec<Instr>) -> Op {
+        Op {
+            kind: "rop".to_string(),
+            id: "test".to_string(),
+            row: 0,
+            col: 0,
+            slot: 0,
+            port: 0,
+            body,
+        }
+    }
+
+    #[test]
+    fn test_transit_with_two_repeats() {
+        let op = make_op(vec![
+            make_instr("dsu", vec![("option", "0"), ("init_addr", "0")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "0"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("dsu", vec![("option", "1"), ("init_addr", "18")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "1"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("trans", vec![("delay", "0")]),
+        ]);
+        assert_eq!(get_timing_model(op), "T<0>(R<4,0>(e0),R<4,0>(e1))");
     }
 }

--- a/lib/resources/iosram_top/sst/iosram_top.cpp
+++ b/lib/resources/iosram_top/sst/iosram_top.cpp
@@ -75,33 +75,84 @@ void Iosram_top::handleActivation(uint32_t slot_id, uint32_t ports) {
 }
 
 void Iosram_top::handleDSU(const IOSRAM_TOP_PKG::DSUInstruction &instr) {
-  out.output("dsu (slot=%d, port=%d, init_addr_sd=%d, init_addr=%d)\n",
-             instr.slot, instr.port, instr.init_addr_sd, instr.init_addr);
+  out.output("dsu (slot=%d, port=%d, option=%d, init_addr_sd=%d, init_addr=%d, "
+             "port=%d)\n",
+             instr.slot, instr.port, instr.option, instr.init_addr_sd,
+             instr.init_addr);
 
-  // Set initial address for the port's AGU
+  // Set initial address
   uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
   agus[port_num].setInitialAddress(instr.init_addr);
+  out.output("Set initial address for port %d to %d\n", port_num,
+             instr.init_addr);
 
+  std::string event_name;
   switch (port_num) {
   case DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO:
-    readFromIO();
+    out.fatal(CALL_INFO, -1,
+              "Invalid DSU mode IOSRAM Btm should not read from IO\n");
+    event_name =
+        "dsu_sram_read_from_io_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO);
+          readFromIO();
+        },
+        1);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO:
     out.fatal(CALL_INFO, -1,
               "Invalid DSU mode IOSRAM Top should not write to IO\n");
-    writeToIO();
+    event_name = "dsu_sram_write_to_io_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO);
+          writeToIO();
+        },
+        9);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM:
-    writeToSRAM();
+    event_name = "dsu_io_write_to_sram_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM);
+          writeToSRAM();
+        },
+        8);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM:
-    readFromSRAM();
+    event_name =
+        "dsu_io_read_from_sram_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM);
+          readFromSRAM();
+        },
+        2);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK:
-    writeBulk();
+    event_name = "dsu_write_bulk_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK);
+          writeBulk();
+        },
+        9);
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_READ_BULK:
-    readBulk();
+    event_name = "dsu_read_bulk_" + std::to_string(current_event_number);
+    agus[instr.port].addEvent(
+        event_name,
+        [this, event_name] {
+          updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK);
+          readBulk();
+        },
+        1);
     break;
 
   default:
@@ -116,27 +167,7 @@ void Iosram_top::handleREP(const IOSRAM_TOP_PKG::REPInstruction &instr) {
   out.output("rep (slot=%d, port=%d, iter=%d, step=%d, delay=%d)\n", instr.slot,
              instr.port, instr.iter, instr.step, instr.delay);
 
-  uint32_t port_num = 0;
-  auto it = std::find(slot_ids.begin(), slot_ids.end(), instr.slot);
-  if (it != slot_ids.end()) {
-    port_num = std::distance(slot_ids.begin(), it);
-  } else {
-    out.fatal(CALL_INFO, -1, "Slot ID not found\n");
-  }
-  port_num = port_num * 4 + instr.port;
-
-  // // For now, we only support increasing repetition levels (and no skipping)
-  // if (instr.level != port_last_rep_level[port_num] + 1) {
-  //   out.output("port_num = %d\n", port_num);
-  //   out.fatal(
-  //       CALL_INFO, -1,
-  //       "Invalid repetition level (last=%d, curr=%d), instruction: (slot: "
-  //       "%d, port: %d, level: %d, iter: %d, step: %d, delay: %d)\n",
-  //       port_last_rep_level[port_num], instr.level, instr.slot, instr.port,
-  //       instr.level, instr.iter, instr.step, instr.delay);
-  // } else {
-  //   port_last_rep_level[port_num] = instr.level;
-  // }
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
 
   // add repetition to the timing model
   try {
@@ -152,15 +183,7 @@ void Iosram_top::handleREPX(const IOSRAM_TOP_PKG::REPXInstruction &instr) {
   out.output("repx (slot=%d, port=%d, iter=%d, step=%d, delay=%d)\n",
              instr.slot, instr.port, instr.iter, instr.step, instr.delay);
 
-  uint32_t port_num = 0;
-  auto it = std::find(slot_ids.begin(), slot_ids.end(), instr.slot);
-  if (it != slot_ids.end()) {
-    port_num = std::distance(slot_ids.begin(), it);
-  } else {
-    out.fatal(CALL_INFO, -1, "Slot ID not found\n");
-  }
-  port_num = port_num * 4 + instr.port;
-
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
   auto repetition_op = agus[port_num].getLastRepetitionOperator();
   uint32_t iter = instr.iter
                       << IOSRAM_TOP_PKG::IOSRAM_TOP_INSTR_REPX_ITER_BITWIDTH |
@@ -180,61 +203,56 @@ void Iosram_top::handleREPX(const IOSRAM_TOP_PKG::REPXInstruction &instr) {
   }
 }
 
+void Iosram_top::handleTRANS(const IOSRAM_TOP_PKG::TRANSInstruction &instr) {
+  out.output("trans (slot=%d, port=%d, delay=%d)\n", instr.slot, instr.port,
+             instr.delay);
+
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
+
+  try {
+    agus[port_num].addTransition(instr.delay);
+    current_event_number++;
+  } catch (const std::exception &e) {
+    out.fatal(CALL_INFO, -1, "Failed to add transition: %s\n", e.what());
+  }
+}
+
 void Iosram_top::readFromIO() {
-  std::string event_name =
-      "dsu_read_from_io_" + std::to_string(current_event_number);
-  // Reading data from the IO to the buffer
-  agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO].addEvent(
-      event_name,
-      [this, event_name] {
-        sram_read_from_io_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO));
+  sram_read_from_io_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO));
 
-        IOReadRequest *readReq = new IOReadRequest();
-        readReq->address = sram_read_from_io_address_buffer;
-        readReq->size = io_data_width / 8;
-        readReq->column_id = cell_coordinates[1];
+  IOReadRequest *readReq = new IOReadRequest();
+  readReq->address = sram_read_from_io_address_buffer;
+  readReq->size = io_data_width / 8;
+  readReq->column_id = cell_coordinates[1];
 
-        out.output("Sending read request to IO (addr=%d, size=%dbits)\n",
-                   sram_read_from_io_address_buffer, io_data_width);
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)sram_read_from_io_address_buffer},
-                       {"size", (int)(io_data_width / 8)}});
+  out.output("Sending read request to IO (addr=%d, size=%dbits)\n",
+             sram_read_from_io_address_buffer, io_data_width);
+  logTraceEvent("iosram_read_from_io", slot_id, true, 'X',
+                {{"address", (int)sram_read_from_io_address_buffer},
+                 {"size", (int)(io_data_width / 8)}});
 
-        io_input_link->send(readReq);
-      },
-      1);
+  io_input_link->send(readReq);
 }
 
 void Iosram_top::writeToIO() {
-  std::string event_name =
-      "dsu_write_to_io_" + std::to_string(current_event_number);
-  // Writing buffer data to the IO
-  agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO].addEvent(
-      event_name,
-      [this, event_name] {
-        sram_write_to_io_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO));
+  sram_write_to_io_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO));
 
-        IOWriteRequest *writeReq = new IOWriteRequest();
-        writeReq->address = sram_write_to_io_address_buffer;
-        writeReq->data = to_io_data_buffer;
-        io_output_link->send(writeReq);
+  IOWriteRequest *writeReq = new IOWriteRequest();
+  writeReq->address = sram_write_to_io_address_buffer;
+  writeReq->data = to_io_data_buffer;
+  io_output_link->send(writeReq);
 
-        out.output(
-            "Sending write request to IO (addr=%d, size=%dbits, data=%s)\n",
-            writeReq->address, writeReq->data.size() * 8,
-            formatRawDataToWords(writeReq->data).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)sram_write_to_io_address_buffer},
-                       {"size", (int)(to_io_data_buffer.size())},
-                       {"data", formatRawDataToWords(to_io_data_buffer)}});
-      },
-      9);
+  out.output("Sending write request to IO (addr=%d, size=%dbits, data=%s)\n",
+             writeReq->address, writeReq->data.size() * 8,
+             formatRawDataToWords(writeReq->data).c_str());
+  logTraceEvent("iosram_write_to_io", slot_id, true, 'X',
+                {{"address", (int)sram_write_to_io_address_buffer},
+                 {"size", (int)(to_io_data_buffer.size())},
+                 {"data", formatRawDataToWords(to_io_data_buffer)}});
 }
 
 std::string Iosram_top::dumpBackendContent() {
@@ -249,141 +267,110 @@ std::string Iosram_top::dumpBackendContent() {
 }
 
 void Iosram_top::writeToSRAM() {
-  std::string event_name =
-      "dsu_write_to_sram_" + std::to_string(current_event_number);
-  // Writing buffer data to the backend
-  agus[DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM].addEvent(
-      event_name,
-      [this, event_name] {
-        // Check if the IO responded
-        IOReadResponse *ioReadResponse =
-            dynamic_cast<IOReadResponse *>(io_input_link->recv());
-        if (ioReadResponse) {
-          out.output("Received read response from IO (addr=%d, size=%dbits, "
-                     "data=%s)\n",
-                     ioReadResponse->address, ioReadResponse->data.size() * 8,
-                     formatRawDataToWords(ioReadResponse->data).c_str());
-          from_io_data_buffer = ioReadResponse->data;
-          if (from_io_data_buffer.size() == 0) {
-            out.fatal(CALL_INFO, -1, "No data from IO\n");
-          }
-        } else {
-          out.fatal(CALL_INFO, -1, "No response from IO\n");
-        }
+  // Check if the IO responded
+  IOReadResponse *ioReadResponse =
+      dynamic_cast<IOReadResponse *>(io_input_link->recv());
+  if (ioReadResponse) {
+    out.output("Received read response from IO (addr=%d, size=%dbits, "
+               "data=%s)\n",
+               ioReadResponse->address, ioReadResponse->data.size() * 8,
+               formatRawDataToWords(ioReadResponse->data).c_str());
+    from_io_data_buffer = ioReadResponse->data;
+    if (from_io_data_buffer.size() == 0) {
+      out.fatal(CALL_INFO, -1, "No data from IO\n");
+    }
+  } else {
+    out.fatal(CALL_INFO, -1, "No response from IO\n");
+  }
 
-        // Calculate the SRAM address
-        io_write_to_sram_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM));
+  // Calculate the SRAM address
+  io_write_to_sram_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM));
 
-        // Write data to the backend (SRAM)
-        backend->set(io_write_to_sram_address_buffer,
-                     from_io_data_buffer.size(), from_io_data_buffer);
-        out.output("Writing to SRAM (addr=%d, size=%dbits, data=%s)\n",
-                   io_write_to_sram_address_buffer,
-                   from_io_data_buffer.size() * 8,
-                   formatRawDataToWords(from_io_data_buffer).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)io_write_to_sram_address_buffer},
-                       {"size", (int)(from_io_data_buffer.size())},
-                       {"data", formatRawDataToWords(from_io_data_buffer)}});
+  // Write data to the backend (SRAM)
+  backend->set(io_write_to_sram_address_buffer, from_io_data_buffer.size(),
+               from_io_data_buffer);
+  out.output("Writing to SRAM (addr=%d, size=%dbits, data=%s)\n",
+             io_write_to_sram_address_buffer, from_io_data_buffer.size() * 8,
+             formatRawDataToWords(from_io_data_buffer).c_str());
+  logTraceEvent("io_write_to_sram", slot_id, true, 'X',
+                {{"address", (int)io_write_to_sram_address_buffer},
+                 {"size", (int)(from_io_data_buffer.size())},
+                 {"data", formatRawDataToWords(from_io_data_buffer)}});
 
-        // Clear the buffer
-        from_io_data_buffer.clear();
+  // Clear the buffer
+  from_io_data_buffer.clear();
 
-        // Log memory state
-        logTraceEvent("memory", slot_id, true, 'E', {});
-        logTraceEvent("memory", slot_id, true, 'B',
-                      {{"memory", dumpBackendContent()}});
-      },
-      8);
+  // Log memory state
+  logTraceEvent("memory", slot_id, true, 'E', {});
+  logTraceEvent("memory", slot_id, true, 'B',
+                {{"memory", dumpBackendContent()}});
 }
 
 void Iosram_top::readFromSRAM() {
-  std::string event_name =
-      "dsu_read_from_sram_" + std::to_string(current_event_number);
-  // Reading data from the backend to the buffer
-  agus[DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM].addEvent(
-      event_name,
-      [this, event_name] {
-        io_read_from_sram_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM]
-                .getAddressForCycle(getPortActiveCycle(
-                    DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM));
+  io_read_from_sram_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM));
 
-        to_io_data_buffer.clear();
-        backend->get(io_read_from_sram_address_buffer, io_data_width / 8,
-                     to_io_data_buffer);
+  to_io_data_buffer.clear();
+  backend->get(io_read_from_sram_address_buffer, io_data_width / 8,
+               to_io_data_buffer);
 
-        out.output("Reading from SRAM (addr=%d, size=%dbits, data=%s)\n",
-                   io_read_from_sram_address_buffer, io_data_width,
-                   formatRawDataToWords(to_io_data_buffer).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)io_read_from_sram_address_buffer},
-                       {"size", (int)(io_data_width / 8)},
-                       {"data", formatRawDataToWords(to_io_data_buffer)}});
-      },
-      2);
+  out.output("Reading from SRAM (addr=%d, size=%dbits, data=%s)\n",
+             io_read_from_sram_address_buffer, io_data_width,
+             formatRawDataToWords(to_io_data_buffer).c_str());
+  logTraceEvent("io_read_from_sram", slot_id, true, 'X',
+                {{"address", (int)io_read_from_sram_address_buffer},
+                 {"size", (int)(io_data_width / 8)},
+                 {"data", formatRawDataToWords(to_io_data_buffer)}});
 }
 
 void Iosram_top::readBulk() {
-  std::string event_name =
-      "dsu_read_bulk_" + std::to_string(current_event_number);
-  agus[DSU_RELATIVE_PORT::DSU_PORT_READ_BULK].addEvent(
-      event_name,
-      [this, event_name] {
-        read_bulk_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_READ_BULK].getAddressForCycle(
-                getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK));
-        DataEvent *dataEvent = new DataEvent(DataEvent::PortType::WriteWide);
-        vector<uint8_t> data;
-        backend->get(read_bulk_address_buffer, io_data_width / 8, data);
-        out.output("Reading bulk data (addr=%d, size=%dbits, data=%s)\n",
-                   read_bulk_address_buffer, io_data_width,
-                   formatRawDataToWords(data).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)read_bulk_address_buffer},
-                       {"size", (int)(io_data_width / 8)},
-                       {"data", formatRawDataToWords(data)}});
-        dataEvent->size = io_data_width;
-        dataEvent->payload = data;
-        data_links[1]->send(dataEvent);
-      },
-      1);
+  read_bulk_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_READ_BULK].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK));
+  out.output("Initiating bulk read (addr=%d, size=%dbits)\n",
+             read_bulk_address_buffer, io_data_width);
+  DataEvent *dataEvent = new DataEvent(DataEvent::PortType::WriteWide);
+  vector<uint8_t> data;
+  backend->get(read_bulk_address_buffer, io_data_width / 8, data);
+  out.output("Reading bulk data (addr=%d, size=%dbits, data=%s)\n",
+             read_bulk_address_buffer, io_data_width,
+             formatRawDataToWords(data).c_str());
+  logTraceEvent("iosram_read_bulk", slot_id, true, 'X',
+                {{"address", (int)read_bulk_address_buffer},
+                 {"size", (int)(io_data_width / 8)},
+                 {"data", formatRawDataToWords(data)}});
+  dataEvent->size = io_data_width;
+  dataEvent->payload = data;
+  data_links[1]->send(dataEvent);
 }
 
 void Iosram_top::writeBulk() {
-  std::string event_name =
-      "dsu_write_bulk_" + std::to_string(current_event_number);
-  agus[DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK].addEvent(
-      event_name,
-      [this, event_name] {
-        write_bulk_address_buffer =
-            agus[DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK].getAddressForCycle(
-                getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK));
+  write_bulk_address_buffer =
+      agus[DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK].getAddressForCycle(
+          getPortActiveCycle(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK));
 
-        // Check if some data was received
-        DataEvent *dataEvent = dynamic_cast<DataEvent *>(data_links[1]->recv());
-        if (dataEvent == nullptr)
-          out.fatal(CALL_INFO, -1, "No data received\n");
+  // Check if some data was received
+  DataEvent *dataEvent = dynamic_cast<DataEvent *>(data_links[1]->recv());
+  if (dataEvent == nullptr)
+    out.fatal(CALL_INFO, -1, "No data received\n");
 
-        // Write data to the backend
-        backend->set(write_bulk_address_buffer, dataEvent->size / 8,
-                     dataEvent->payload);
+  // Write data to the backend
+  backend->set(write_bulk_address_buffer, dataEvent->size / 8,
+               dataEvent->payload);
 
-        out.output("Writing bulk data (addr=%d, size=%dbits, data=%s)\n",
-                   write_bulk_address_buffer, dataEvent->size,
-                   formatRawDataToWords(dataEvent->payload).c_str());
-        logTraceEvent(event_name, slot_id, true, 'X',
-                      {{"address", (int)write_bulk_address_buffer},
-                       {"size", (int)(dataEvent->size / 8)},
-                       {"data", formatRawDataToWords(dataEvent->payload)}});
+  out.output("Writing bulk data (addr=%d, size=%dbits, data=%s)\n",
+             write_bulk_address_buffer, dataEvent->size,
+             formatRawDataToWords(dataEvent->payload).c_str());
+  logTraceEvent("iosram_write_bulk", slot_id, true, 'X',
+                {{"address", (int)write_bulk_address_buffer},
+                 {"size", (int)(dataEvent->size / 8)},
+                 {"data", formatRawDataToWords(dataEvent->payload)}});
 
-        // Log memory state
-        logTraceEvent("memory", slot_id, true, 'E', {});
-        logTraceEvent("memory", slot_id, true, 'B',
-                      {{"memory", dumpBackendContent()}});
-      },
-      9);
+  // Log memory state
+  logTraceEvent("memory", slot_id, true, 'E', {});
+  logTraceEvent("memory", slot_id, true, 'B',
+                {{"memory", dumpBackendContent()}});
 }

--- a/lib/resources/iosram_top/sst/iosram_top.cpp
+++ b/lib/resources/iosram_top/sst/iosram_top.cpp
@@ -11,7 +11,7 @@ Iosram_top::Iosram_top(SST::ComponentId_t id, SST::Params &params)
     : DRRAResource(id, params) {
   instructionHandlers = IOSRAM_TOP_PKG::createInstructionHandlers(this);
   access_time = params.find<std::string>("access_time", "0ns");
-  iosram_depth = 1u << params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
+  iosram_depth = 1ULL << params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
   read_only = params.find<bool>("read_only", false);
 
   // Backing store
@@ -75,10 +75,10 @@ void Iosram_top::handleActivation(uint32_t slot_id, uint32_t ports) {
 }
 
 void Iosram_top::handleDSU(const IOSRAM_TOP_PKG::DSUInstruction &instr) {
-  out.output("dsu (slot=%d, port=%d, option=%d, init_addr_sd=%d, init_addr=%d, "
-             "port=%d)\n",
-             instr.slot, instr.port, instr.option, instr.init_addr_sd,
-             instr.init_addr);
+  out.output(
+      "dsu (slot=%d, port=%d, option=%d, init_addr_sd=%d, init_addr=%d)\n",
+      instr.slot, instr.port, instr.option, instr.init_addr_sd,
+      instr.init_addr);
 
   // Set initial address
   uint32_t port_num = getRelativePortNum(instr.slot, instr.port);

--- a/lib/resources/iosram_top/sst/iosram_top.cpp
+++ b/lib/resources/iosram_top/sst/iosram_top.cpp
@@ -11,7 +11,7 @@ Iosram_top::Iosram_top(SST::ComponentId_t id, SST::Params &params)
     : DRRAResource(id, params) {
   instructionHandlers = IOSRAM_TOP_PKG::createInstructionHandlers(this);
   access_time = params.find<std::string>("access_time", "0ns");
-  iosram_depth = 2 ^ params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
+  iosram_depth = 1u << params.find<uint32_t>("SRAM_ADDR_WIDTH", 6);
   read_only = params.find<bool>("read_only", false);
 
   // Backing store

--- a/lib/resources/iosram_top/sst/iosram_top.cpp
+++ b/lib/resources/iosram_top/sst/iosram_top.cpp
@@ -89,11 +89,9 @@ void Iosram_top::handleDSU(const IOSRAM_TOP_PKG::DSUInstruction &instr) {
   std::string event_name;
   switch (port_num) {
   case DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO:
-    out.fatal(CALL_INFO, -1,
-              "Invalid DSU mode IOSRAM Btm should not read from IO\n");
     event_name =
         "dsu_sram_read_from_io_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_READ_FROM_IO);
@@ -105,7 +103,7 @@ void Iosram_top::handleDSU(const IOSRAM_TOP_PKG::DSUInstruction &instr) {
     out.fatal(CALL_INFO, -1,
               "Invalid DSU mode IOSRAM Top should not write to IO\n");
     event_name = "dsu_sram_write_to_io_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_SRAM_WRITE_TO_IO);
@@ -115,7 +113,7 @@ void Iosram_top::handleDSU(const IOSRAM_TOP_PKG::DSUInstruction &instr) {
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM:
     event_name = "dsu_io_write_to_sram_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_WRITE_TO_SRAM);
@@ -126,7 +124,7 @@ void Iosram_top::handleDSU(const IOSRAM_TOP_PKG::DSUInstruction &instr) {
   case DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM:
     event_name =
         "dsu_io_read_from_sram_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_IO_READ_FROM_SRAM);
@@ -136,7 +134,7 @@ void Iosram_top::handleDSU(const IOSRAM_TOP_PKG::DSUInstruction &instr) {
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK:
     event_name = "dsu_write_bulk_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_WRITE_BULK);
@@ -146,7 +144,7 @@ void Iosram_top::handleDSU(const IOSRAM_TOP_PKG::DSUInstruction &instr) {
     break;
   case DSU_RELATIVE_PORT::DSU_PORT_READ_BULK:
     event_name = "dsu_read_bulk_" + std::to_string(current_event_number);
-    agus[instr.port].addEvent(
+    agus[port_num].addEvent(
         event_name,
         [this, event_name] {
           updatePortAGUs(DSU_RELATIVE_PORT::DSU_PORT_READ_BULK);

--- a/lib/resources/iosram_top/sst/iosram_top.h
+++ b/lib/resources/iosram_top/sst/iosram_top.h
@@ -122,15 +122,21 @@ private:
   std::unordered_map<uint32_t, uint32_t> portsToActivate;
 
   void updatePortAGUs(uint32_t port) {
-    port_agus[port] = port_agus_init[port] +
-                      agus[port].getAddressForCycle(getPortActiveCycle(port));
+    int64_t address_offset =
+        agus[port].getAddressForCycle(getPortActiveCycle(port));
+    if (address_offset < 0) {
+      out.fatal(CALL_INFO, -1,
+                "AGU for port %u returned negative address %d for cycle %d\n",
+                port, address_offset, getPortActiveCycle(port));
+    }
+    port_agus[port] = port_agus_init[port] + address_offset;
     uint64_t max_addr = iosram_depth;
-    if (port == DSU_PORT_SRAM_READ_FROM_IO || port == DSU_PORT_SRAM_WRITE_TO_IO) {
+    if (port == DSU_PORT_SRAM_READ_FROM_IO ||
+        port == DSU_PORT_SRAM_WRITE_TO_IO) {
       max_addr = iosram_depth * (io_data_width / word_bitwidth);
     }
     if (port_agus[port] >= max_addr) {
-      out.fatal(CALL_INFO, -1,
-                "Invalid AGU address %u for port %u (max %lu)\n",
+      out.fatal(CALL_INFO, -1, "Invalid AGU address %u for port %u (max %lu)\n",
                 port_agus[port], port, max_addr);
     }
   }

--- a/lib/resources/iosram_top/sst/iosram_top.h
+++ b/lib/resources/iosram_top/sst/iosram_top.h
@@ -59,8 +59,6 @@ public:
   bool clockTick(SST::Cycle_t currentCycle) override;
   void handleActivation(uint32_t slot_id, uint32_t ports) override;
 
-  std::unordered_map<uint32_t, uint32_t> portsToActivate;
-
   // Instruction format
   using DRRAResource::format;
   void handleDSU(const IOSRAM_TOP_PKG::DSUInstruction &instr);
@@ -84,6 +82,8 @@ private:
   std::string dumpBackendContent();
   SST::MemHierarchy::Backend::Backing *backend = nullptr;
   ScratchBackendConvertor *backendConvertor = nullptr;
+
+  void switchToNextOption_sram(uint32_t port_num);
 
   // Backing store parameters
   uint64_t iosram_depth;
@@ -114,9 +114,21 @@ private:
   void writeBulk();
   void readBulk();
 
-  int32_t agu_initial_addr = -1;
   uint32_t current_event_number = 0;
   std::map<uint32_t, size_t> current_option_config;
+  std::map<uint32_t, uint32_t> port_agus_init;
+  std::map<uint32_t, uint32_t> port_agus;
+
+  std::unordered_map<uint32_t, uint32_t> portsToActivate;
+
+  void updatePortAGUs(uint32_t port) {
+    port_agus[port] = port_agus_init[port] +
+                      agus[port].getAddressForCycle(getPortActiveCycle(port));
+    if (port_agus[port] >= iosram_depth) {
+      out.fatal(CALL_INFO, -1,
+                "Invalid AGU address (greater than IOSRAM size)\n");
+    }
+  }
 };
 
 #endif // _IOSRAM_TOP_H

--- a/lib/resources/iosram_top/sst/iosram_top.h
+++ b/lib/resources/iosram_top/sst/iosram_top.h
@@ -124,9 +124,14 @@ private:
   void updatePortAGUs(uint32_t port) {
     port_agus[port] = port_agus_init[port] +
                       agus[port].getAddressForCycle(getPortActiveCycle(port));
-    if (port_agus[port] >= iosram_depth) {
+    uint64_t max_addr = iosram_depth;
+    if (port == DSU_PORT_SRAM_READ_FROM_IO || port == DSU_PORT_SRAM_WRITE_TO_IO) {
+      max_addr = iosram_depth * (io_data_width / word_bitwidth);
+    }
+    if (port_agus[port] >= max_addr) {
       out.fatal(CALL_INFO, -1,
-                "Invalid AGU address (greater than IOSRAM size)\n");
+                "Invalid AGU address %u for port %u (max %lu)\n",
+                port_agus[port], port, max_addr);
     }
   }
 };

--- a/lib/resources/rf/compile_util/src/main.rs
+++ b/lib/resources/rf/compile_util/src/main.rs
@@ -33,7 +33,6 @@ use serde_json::json;
  *
  */
 use serde_json::Value;
-use std::collections::HashMap;
 use std::env;
 use std::ops::{Deref, DerefMut};
 
@@ -44,34 +43,31 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_level = [0, 0, 0, 0];
-    let mut current_trans = [0, 0, 0, 0];
-    let mut t: HashMap<i64, String> = HashMap::new();
-    let mut r: HashMap<i64, (String, String)> = HashMap::new();
-    let mut expr = "e0".to_string();
+    let mut segments: Vec<String> = Vec::new();
+    let mut event_counter = 0;
 
     for instr in op.body {
         let instr_segments = instr.params;
         match instr.kind.as_str() {
             "dsu" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
-                current_level[port] = 0;
-                current_trans[port] = 0;
+                segments.push(format!("e{}", event_counter));
+                event_counter += 1;
             }
             "rep" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let iter = instr_segments.get_value("iter");
                 let delay = instr_segments.get_value("delay");
-                r.insert(current_level[port], (iter.to_string(), delay.to_string()));
-                current_level[port] += 1;
+                if let Some(last) = segments.last_mut() {
+                    *last = format!("R<{},{}>({})", iter, delay, last);
+                }
             }
             "repx" => {}
             "trans" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let delay = instr_segments.get_value("delay");
-                t.insert(current_trans[port], delay);
-                current_level[port] = 0;
-                current_trans[port] += 1;
+                if segments.len() >= 2 {
+                    let right = segments.pop().unwrap();
+                    let left = segments.pop().unwrap();
+                    segments.push(format!("T<{}>({},{})", delay, left, right));
+                }
             }
             _ => {
                 panic!("Unknown instruction kind: {}", instr.kind);
@@ -79,31 +75,7 @@ fn get_timing_model(op: Op) -> String {
         }
     }
 
-    let mut event_counter = 1;
-    let mut t_keys: Vec<_> = t.keys().cloned().collect();
-    t_keys.sort();
-    for i in t_keys {
-        if let Some(delay) = t.get(&i) {
-            if delay != "0" {
-                expr = format!("T<{}>({}, e{})", delay, expr, event_counter);
-                event_counter += 1;
-            } else {
-                break;
-            }
-        }
-    }
-
-    let mut r_keys: Vec<_> = r.keys().cloned().collect();
-    r_keys.sort();
-    for i in r_keys {
-        if let Some(values) = r.get(&i) {
-            expr = format!("R<{},{}>({})", values.0, values.1, expr);
-        } else {
-            break;
-        }
-    }
-
-    expr
+    segments.pop().unwrap_or_else(|| "e0".to_string())
 }
 
 fn reshape_instr(op: Op) -> Op {
@@ -389,5 +361,63 @@ fn main() {
             std::fs::write(output_file, serde_json::to_string(&reshaped_json).unwrap()).unwrap();
         }
         _ => panic!("Unknown subcommand: {}", subcommand),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_instr(kind: &str, params: Vec<(&str, &str)>) -> Instr {
+        Instr {
+            kind: kind.to_string(),
+            id: "".to_string(),
+            params: InstrSegments::new(
+                params
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
+        }
+    }
+
+    fn make_op(body: Vec<Instr>) -> Op {
+        Op {
+            kind: "rop".to_string(),
+            id: "test".to_string(),
+            row: 0,
+            col: 0,
+            slot: 0,
+            port: 0,
+            body,
+        }
+    }
+
+    #[test]
+    fn test_transit_with_two_repeats() {
+        let op = make_op(vec![
+            make_instr("dsu", vec![("option", "0"), ("init_addr", "0")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "0"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("dsu", vec![("option", "1"), ("init_addr", "18")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "1"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("trans", vec![("delay", "0")]),
+        ]);
+        assert_eq!(get_timing_model(op), "T<0>(R<4,0>(e0),R<4,0>(e1))");
     }
 }

--- a/lib/resources/rf/compile_util/src/main.rs
+++ b/lib/resources/rf/compile_util/src/main.rs
@@ -61,7 +61,6 @@ fn get_timing_model(op: Op) -> String {
             "rep" => {
                 let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let iter = instr_segments.get_value("iter");
-                let _step = instr_segments.get_value("step");
                 let delay = instr_segments.get_value("delay");
                 r.insert(current_level[port], (iter.to_string(), delay.to_string()));
                 current_level[port] += 1;

--- a/lib/resources/rf/sst/rf.cpp
+++ b/lib/resources/rf/sst/rf.cpp
@@ -107,14 +107,7 @@ void Rf::handleREP(const RF_PKG::REPInstruction &instr) {
              instr.port, instr.iter, instr.step, instr.delay);
 
   auto rep = instr;
-  uint32_t port_num = 0;
-  auto it = std::find(slot_ids.begin(), slot_ids.end(), rep.slot);
-  if (it != slot_ids.end()) {
-    port_num = std::distance(slot_ids.begin(), it);
-  } else {
-    out.fatal(CALL_INFO, -1, "Slot ID not found\n");
-  }
-  port_num = port_num * 4 + rep.port;
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
 
   // Add repetition to the timing model
   try {
@@ -129,14 +122,7 @@ void Rf::handleREPX(const RF_PKG::REPXInstruction &instr) {
              instr.slot, instr.port, instr.iter, instr.step, instr.delay);
 
   auto repx = instr;
-  uint32_t port_num = 0;
-  auto it = std::find(slot_ids.begin(), slot_ids.end(), repx.slot);
-  if (it != slot_ids.end()) {
-    port_num = std::distance(slot_ids.begin(), it);
-  } else {
-    out.fatal(CALL_INFO, -1, "Slot ID not found\n");
-  }
-  port_num = port_num * 4 + repx.port;
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
 
   auto repetition_op = agus[port_num].getLastRepetitionOperator();
   uint32_t iter = repx.iter << RF_PKG::RF_INSTR_REPX_ITER_BITWIDTH |
@@ -157,9 +143,9 @@ void Rf::handleTRANS(const RF_PKG::TRANSInstruction &instr) {
   out.output("trans (slot=%d, port=%s, delay=%d)\n", instr.slot,
              instr.port == 0 ? "dpu" : "rst", instr.delay);
 
-  // Add transition to the timing model
+  uint32_t port_num = getRelativePortNum(instr.slot, instr.port);
   try {
-    agus[instr.port].addTransition(instr.delay);
+    agus[port_num].addTransition(instr.delay);
     current_event_number++;
   } catch (const std::exception &e) {
     out.fatal(CALL_INFO, -1, "Failed to add transition: %s\n", e.what());

--- a/lib/resources/swb/compile_util/src/main.rs
+++ b/lib/resources/swb/compile_util/src/main.rs
@@ -33,7 +33,6 @@ use serde_json::json;
  *
  */
 use serde_json::Value;
-use std::collections::HashMap;
 use std::env;
 use std::ops::{Deref, DerefMut};
 
@@ -44,37 +43,32 @@ include!("isa_config.rs");
  ******************************************************************************/
 
 fn get_timing_model(op: Op) -> String {
-    let mut current_level = [0, 0];
-    let mut current_trans = [0, 0];
-    let mut t: HashMap<i64, String> = HashMap::new();
-    let mut r: HashMap<i64, (String, String)> = HashMap::new();
-    let mut expr = "e0".to_string();
+    let mut segments: Vec<String> = Vec::new();
+    let mut event_counter = 0;
 
     for instr in op.body {
         let instr_segments = instr.params;
         match instr.kind.as_str() {
             "swb" | "route" => {}
             "evt" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
-                current_level[port] = 0;
-                current_trans[port] = 0;
+                segments.push(format!("e{}", event_counter));
+                event_counter += 1;
             }
             "rep" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
-                let mut iter = instr_segments.get_value("iter");
-                let _step = instr_segments.get_value("step");
+                let iter = instr_segments.get_value("iter");
                 let delay = instr_segments.get_value("delay");
-                iter = (iter.parse::<i64>().unwrap()).to_string();
-                r.insert(current_level[port], (iter, delay.to_string()));
-                current_level[port] += 1;
+                if let Some(last) = segments.last_mut() {
+                    *last = format!("R<{},{}>({})", iter, delay, last);
+                }
             }
             "repx" => {}
             "trans" => {
-                let port = instr_segments.get_value("port").parse::<usize>().unwrap();
                 let delay = instr_segments.get_value("delay");
-                t.insert(current_trans[port], delay);
-                current_level[port] = 0;
-                current_trans[port] += 1;
+                if segments.len() >= 2 {
+                    let right = segments.pop().unwrap();
+                    let left = segments.pop().unwrap();
+                    segments.push(format!("T<{}>({},{})", delay, left, right));
+                }
             }
             _ => {
                 panic!("Unknown instruction kind: {}", instr.kind);
@@ -82,31 +76,7 @@ fn get_timing_model(op: Op) -> String {
         }
     }
 
-    let mut event_counter = 1;
-    let mut t_keys: Vec<_> = t.keys().cloned().collect();
-    t_keys.sort();
-    for i in t_keys {
-        if let Some(delay) = t.get(&i) {
-            if delay != "0" {
-                expr = format!("T<{}>({}, e{})", delay, expr, event_counter);
-                event_counter += 1;
-            } else {
-                break;
-            }
-        }
-    }
-
-    let mut r_keys: Vec<_> = r.keys().cloned().collect();
-    r_keys.sort();
-    for i in r_keys {
-        if let Some(values) = r.get(&i) {
-            expr = format!("R<{},{}>({})", values.0, values.1, expr);
-        } else {
-            break;
-        }
-    }
-
-    expr
+    segments.pop().unwrap_or_else(|| "e0".to_string())
 }
 
 fn reshape_instr(op: Op) -> Op {
@@ -387,5 +357,63 @@ fn main() {
             std::fs::write(output_file, serde_json::to_string(&reshaped_json).unwrap()).unwrap();
         }
         _ => panic!("Unknown subcommand: {}", subcommand),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_instr(kind: &str, params: Vec<(&str, &str)>) -> Instr {
+        Instr {
+            kind: kind.to_string(),
+            id: "".to_string(),
+            params: InstrSegments::new(
+                params
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            ),
+        }
+    }
+
+    fn make_op(body: Vec<Instr>) -> Op {
+        Op {
+            kind: "rop".to_string(),
+            id: "test".to_string(),
+            row: 0,
+            col: 0,
+            slot: 0,
+            port: 0,
+            body,
+        }
+    }
+
+    #[test]
+    fn test_transit_with_two_repeats() {
+        let op = make_op(vec![
+            make_instr("evt", vec![("option", "0")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "0"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("evt", vec![("option", "1")]),
+            make_instr(
+                "rep",
+                vec![
+                    ("option", "1"),
+                    ("iter", "4"),
+                    ("step", "1"),
+                    ("delay", "0"),
+                ],
+            ),
+            make_instr("trans", vec![("delay", "0")]),
+        ]);
+        assert_eq!(get_timing_model(op), "T<0>(R<4,0>(e0),R<4,0>(e1))");
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the timing model infrastructure and related utilities across the codebase. The main focus is on supporting per-event initial addresses, simplifying the logic for constructing timing expressions in Rust utilities, and enhancing debugging support. Additionally, a bug fix in the SRAM depth calculation is included.

**Timing model infrastructure improvements:**

* Added support for per-event initial addresses in the timing model:
  * Introduced a `lane_initial_addresses` vector in `DRRA_AGU` to track initial addresses for each event and propagate them into `TimingState` (`drra_agu.h`, `drra_agu.cpp`). [[1]](diffhunk://#diff-3498196413c8bb880b9cb764d763e6db56961b51dfa492596b05b179b4da8fb0R10) [[2]](diffhunk://#diff-8951cce4823485d2b1a948511213a2c94aa9c284ef0c44e558caec1da01c91fcR40) [[3]](diffhunk://#diff-8951cce4823485d2b1a948511213a2c94aa9c284ef0c44e558caec1da01c91fcR212) [[4]](diffhunk://#diff-8951cce4823485d2b1a948511213a2c94aa9c284ef0c44e558caec1da01c91fcR228)
  * Modified `TimingState` to store and use `eventInitialAddresses`, ensuring each event can start from its own initial address. The build logic now initializes event addresses accordingly (`timingExpression.h`, `timingExpression.cpp`). [[1]](diffhunk://#diff-5c8509fc1a79f6d628e938872de35d83b259feca15d08a2dc91387f85c82e341L31-R39) [[2]](diffhunk://#diff-5c8509fc1a79f6d628e938872de35d83b259feca15d08a2dc91387f85c82e341R99) [[3]](diffhunk://#diff-c73f96dac9507f6a92978c1943ee34817432c48b55ffde1899126ecc6ed7439dR31) [[4]](diffhunk://#diff-c73f96dac9507f6a92978c1943ee34817432c48b55ffde1899126ecc6ed7439dR119) [[5]](diffhunk://#diff-c73f96dac9507f6a92978c1943ee34817432c48b55ffde1899126ecc6ed7439dL424-R435) [[6]](diffhunk://#diff-c73f96dac9507f6a92978c1943ee34817432c48b55ffde1899126ecc6ed7439dR722-R726)
  * Adjusted address calculation in `DRRA_AGU::getAddressForCycle` to avoid double-adding the initial address.

* Enhanced debugging capabilities:
  * Added detailed debug output for event scheduling and retrieval in `TimingState` and event execution in `DRRAResource`. [[1]](diffhunk://#diff-4846482db08bfda4e7e16b9dc78ba116784f02da718c5c893dbc868351354fb1L202-R206) [[2]](diffhunk://#diff-c73f96dac9507f6a92978c1943ee34817432c48b55ffde1899126ecc6ed7439dR580-R611) [[3]](diffhunk://#diff-c73f96dac9507f6a92978c1943ee34817432c48b55ffde1899126ecc6ed7439dR643-R653)

**Rust timing model utility simplifications:**

* Refactored the `get_timing_model` function in both DPU and IOSRAM Rust utilities to use a stack-based approach for constructing timing expressions, replacing the previous complex logic with hashmaps. This makes the code easier to follow and maintain. [[1]](diffhunk://#diff-8bff5062631c80d412f373237cc72ddc58212923b9b2549e3e82625194ea8d62L47-R47) [[2]](diffhunk://#diff-8bff5062631c80d412f373237cc72ddc58212923b9b2549e3e82625194ea8d62L60-R81) [[3]](diffhunk://#diff-83b584b825cf488b1594a2b17c52e8e0b9649344e67c34564af1f98caa1dd158L47-R78)
* Added unit tests for timing model construction in both Rust utilities to verify correct behavior. [[1]](diffhunk://#diff-8bff5062631c80d412f373237cc72ddc58212923b9b2549e3e82625194ea8d62R369-R426) [[2]](diffhunk://#diff-83b584b825cf488b1594a2b17c52e8e0b9649344e67c34564af1f98caa1dd158R365-R422)

**Bug fixes:**

* Corrected the calculation of SRAM depth in `Iosram_both` from bitwise XOR to a left shift, ensuring proper memory sizing.