### PR TITLE
fix(bender): correct/drop dangling common deps for bender 0.32

### DIFF
--- a/lib/resources/dpu/Bender.yml
+++ b/lib/resources/dpu/Bender.yml
@@ -2,7 +2,6 @@ package:
   name: dpu
 
 dependencies:
-  fsm: { path: ../../common/fsm }
   agu_rtr: { path: ../../common/agu_RTR }
 
 sources:

--- a/lib/resources/rf/Bender.yml
+++ b/lib/resources/rf/Bender.yml
@@ -2,7 +2,7 @@ package:
   name: rf
 
 dependencies:
-  agu: { path: ../../common/agu }
+  agu_rtr: { path: ../../common/agu_RTR }
 
 sources:
   - ./rtl/rf_pkg.sv

--- a/lib/resources/swb/Bender.yml
+++ b/lib/resources/swb/Bender.yml
@@ -2,7 +2,6 @@ package:
   name: swb
 
 dependencies:
-  fsm: { path: ../../common/fsm }
   agu_rtr: { path: ../../common/agu_RTR }
 
 sources:


### PR DESCRIPTION
## Why
bender 0.32 hard-errors (E32) on dependencies whose source path does not exist, where older bender (0.28) only warned. Three resource manifests declared deps that don't resolve, breaking `vesyla testcase run` generation and RTL sim.

## Changes
- **rf**: `agu: ../../common/agu` → `agu_rtr: ../../common/agu_RTR`. `common/agu` does not exist; rf's RTL imports `agu_rtr_pkg`, so the correct dependency is `agu_RTR` (consistent with swb/dpu/acc/vpu).
- **swb, dpu**: drop the unused `fsm: ../../common/fsm` dependency (`common/fsm` no longer exists).

## Validation
With these + the companion vesyla fixes (strip deps for `bender flist`; don't fingerprint the fabric package name), the full arithmetic + arithmetic_no_sram suite (24 testcases × 10 runs = 240) passes end-to-end on bender 0.32 — C++ model, instruction sim, and RTL sim all green, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)