### PR TITLE
fix: fabric synthesizability — swb latches + dpu agu_done index

### DIFF
--- a/lib/resources/dpu/rtl/controller.sv.j2
+++ b/lib/resources/dpu/rtl/controller.sv.j2
@@ -64,7 +64,7 @@ import {{name}}_{{fingerprint}}_pkg::*;
       current_rep_level   <= '{default: '0};
       current_trans_index   <= '{default: '0};
     end else begin
-      for (int i = 0; i < FSM_PER_SLOT; i++) begin
+      for (int i = 0; i < NUM_AGUS; i++) begin
         if (agu_done[i]) begin
           agu_configs_reg[i]     <= '0;
           use_or_reg[i]          <= 1'b0;

--- a/lib/resources/swb/rtl/controller.sv.j2
+++ b/lib/resources/swb/rtl/controller.sv.j2
@@ -131,7 +131,7 @@ import {{name}}_{{fingerprint}}_pkg::*;
 
   always_ff @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
-      agu_configs_reg   <= '{default: '{default: '0}};
+      agu_configs_reg   <= '{default: '0};
       use_or_reg        <= '{default: 1'b0};
       or_configured_reg <= '{default: 1'b0};
       current_option    <= '{default: '1};

--- a/lib/resources/swb/rtl/swb.sv.j2
+++ b/lib/resources/swb/rtl/swb.sv.j2
@@ -160,9 +160,12 @@ import {{name}}_{{fingerprint}}_pkg::*;
     endgenerate
 
     // SWB word channel routing logic
-    always_comb
+    always_comb begin
+      // Default assignment prevents a latch on slots not selected by slot_link
+      word_channels_out = '0;
       for (int i=0; i < NUM_SLOTS; i++)
         word_channels_out[curr_swb_configs.slot_link[i]] = word_channels_in[i];
+    end
 
     logic [BULK_BITWIDTH-1:0] bulk_local_channel;
 


### PR DESCRIPTION
## What
RTL synthesizability fixes for the resource templates, found while running
Cadence Genus on a real assembled one-cell fabric (io + rf + swb + dpu,
stdcell-only, no SRAM):

1. **swb `agu_configs_reg`** (`swb/rtl/controller.sv.j2`) — use the single
   default-assignment pattern.
2. **swb `word_channels_out`** (`swb/rtl/swb.sv.j2`) — the word-channel
   routing `always_comb` only wrote the slots selected by
   `slot_link[i]` (a data-dependent index), so unselected output slots held
   their value → inferred latch per bit. Add a `'0` default before the loop,
   matching the ROUTE send/receive blocks.
3. **dpu `agu_done` reset loop** (`dpu/rtl/controller.sv.j2`) — looped
   `i < FSM_PER_SLOT` (4) while indexing `agu_done`, which is `[NUM_AGUS-1:0]`
   (2) along with every array it writes. `agu_done[2]` is out of range and
   aborts elaboration. Bound the loop by `NUM_AGUS`.

## Why
Simulation does not exercise synthesis. Genus elaboration (with
`hdl_error_on_latch` / `hdl_error_on_blackbox`) flags incomplete-assignment
latches and out-of-range indexing that `vlog` accepts silently. (1) and (2)
are the same default-assignment class; (3) is a loop-bound/width mismatch.

## Testing
With all three applied, the assembled one-cell fabric elaborates clean in
Genus (0 errors, 0 inferred latches) and proceeds through
`syn_generic`/`syn_map`/`syn_opt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Supersedes #124 (auto-closed when its branch `fix/swb-default-pattern` was renamed to `fix/synth-elaboration-bugs`)._
